### PR TITLE
Add View Specific Student Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
 import seedu.address.ui.Ui.UiState;
 
 /**
@@ -20,16 +21,22 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** UI State should be changed accordingly. */
     private final UiState uiState;
+
+    /** Details of person should be displayed */
+    private final Person personToView;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    private CommandResult(String feedbackToUser, boolean showHelp, boolean exit, UiState uiState) {
+    private CommandResult(String feedbackToUser, boolean showHelp, boolean exit, UiState uiState,
+                          Person personToView) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.uiState = uiState;
+        this.personToView = personToView;
     }
 
     /**
@@ -38,7 +45,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this(feedbackToUser, showHelp, exit, UiState.DETAILS);
+        this(feedbackToUser, showHelp, exit, UiState.DETAILS, null);
     }
 
     /**
@@ -47,7 +54,16 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser, UiState uiState) {
-        this(feedbackToUser, false, false, uiState);
+        this(feedbackToUser, false, false, uiState, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * {@code showHelp}, and {@code exit},
+     * and other fields set to their default value.
+     */
+    public CommandResult(String feedbackToUser, Person personToView) {
+        this(feedbackToUser, false, false, UiState.SPECIFIC_DETAILS, personToView);
     }
 
     public String getFeedbackToUser() {
@@ -64,6 +80,10 @@ public class CommandResult {
 
     public UiState getUiState() {
         return uiState;
+    }
+
+    public Person getPersonToView() {
+        return personToView;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -101,12 +101,13 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && uiState == otherCommandResult.uiState;
+                && uiState == otherCommandResult.uiState
+                && personToView == otherCommandResult.personToView;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, uiState);
+        return Objects.hash(feedbackToUser, showHelp, exit, uiState, personToView);
     }
 
     @Override
@@ -116,6 +117,7 @@ public class CommandResult {
                 .add("showHelp", showHelp)
                 .add("exit", exit)
                 .add("uiState", uiState)
+                .add("personToView", personToView)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -54,7 +54,7 @@ public class NoteCommand extends Command {
         Person personToEdit = null;
 
         for (Person person : allStudents) {
-            if (person.getName().toString().equals(name.toString())) {
+            if (person.getName().equals(name)) {
                 personToEdit = person;
             }
         }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+
+/**
+ * Views the details of an existing student in the address book.
+ */
+public class ViewCommand extends Command {
+
+    public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views the details of the student identified.\n"
+            + "Parameters: " + PREFIX_NAME + "NAME";
+
+    public static final String MESSAGE_VIEW_SUCCESS = "Displayed details of Person: %1$s";
+
+    public final Name name;
+
+    /**
+     * @param name of the person in the filtered person list to view details
+     */
+    public ViewCommand(Name name) {
+        requireAllNonNull(name);
+        this.name = name;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> allStudents = model.getAddressBook().getPersonList();
+        Person personToView = null;
+
+        for (Person person : allStudents) {
+            if (person.getName().equals(name)) {
+                personToView = person;
+            }
+        }
+
+        if (personToView == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NAME);
+        }
+
+        return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, name),
+                personToView);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+        // instanceof handles nulls
+        if (!(other instanceof ViewCommand)) {
+            return false;
+        }
+        // state check
+        ViewCommand e = (ViewCommand) other;
+        return name.equals(e.name);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.commands.UpdateTaskCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.commands.ViewTasksCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -106,6 +107,9 @@ public class AddressBookParser {
 
         case UpdateTaskCommand.COMMAND_WORD:
             return new UpdateTaskCommandParser().parse(arguments);
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         case ViewTasksCommand.COMMAND_WORD:
             return new ViewTasksCommand();

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -3,7 +3,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -2,10 +2,10 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.ParserUtil.parseName;
 
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Name;
 
 /**
  * Parses input arguments and creates a new {@code ViewCommand} object
@@ -29,6 +29,6 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
-        return new ViewCommand(new Name(name));
+        return new ViewCommand(parseName(name));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,36 +1,35 @@
 package seedu.address.logic.parser;
-
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import seedu.address.logic.commands.NoteCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.Note;
 
 /**
- * Parses input arguments and creates a new {@code NoteCommand} object
+ * Parses input arguments and creates a new {@code ViewCommand} object
  */
-public class NoteCommandParser implements Parser<NoteCommand> {
+public class ViewCommandParser implements Parser<ViewCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the {@code NoteCommand}
-     * and returns a {@code NoteCommand} object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@code ViewCommand}
+     * and returns a {@code ViewCommand} object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public NoteCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NOTE);
+    public ViewCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
 
         String name = argMultimap.getValue(PREFIX_NAME).orElse("");
-        String note = argMultimap.getValue(PREFIX_NOTE).orElse("");
 
         if (name.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));
         }
 
-        return new NoteCommand(new Name(name), new Note(note));
+        return new ViewCommand(new Name(name));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -27,7 +27,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
 
         if (name.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
         return new ViewCommand(new Name(name));

--- a/src/main/java/seedu/address/ui/DetailsDisplay.java
+++ b/src/main/java/seedu/address/ui/DetailsDisplay.java
@@ -1,0 +1,66 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Person;
+
+/**
+ * A UI component that displays details of a specific {@code Person}.
+ */
+public class DetailsDisplay extends UiPart<Region> {
+
+    private static final String FXML = "DetailsDisplay.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Person person;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label phone;
+    @FXML
+    private Label emergencyContact;
+    @FXML
+    private Label address;
+    @FXML
+    private Label note;
+    @FXML
+    private FlowPane subjects;
+    @FXML
+    private Label level;
+    @FXML
+    private Label tasks;
+
+    /**
+     * Creates a {@code PersonCard} with the given {@code Person} and index to display.
+     */
+    public DetailsDisplay(Person person) {
+        super(FXML);
+        this.person = person;
+        name.setText(person.getName().fullName);
+        phone.setText("Phone number: " + person.getPhone().value);
+        emergencyContact.setText("Emergency Contact: " + person.getEmergencyContact().value);
+        address.setText("Address: " + person.getAddress().value);
+        note.setText(person.getNote().value);
+        person.getSubjects().stream()
+                .sorted(Comparator.comparing(subject -> subject.subjectName))
+                .forEach(subject -> subjects.getChildren()
+                        .add(new Label(person.getLevel().levelName + " " + subject.subjectName)));
+        tasks.setText(person.getTaskList().toDescription());
+    }
+}
+

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
@@ -50,6 +51,12 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane statusbarPlaceholder;
+
+    @FXML
+    private StackPane detailsDisplayPlaceholder;
+
+    @FXML
+    private SplitPane mainSplitPane;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -122,6 +129,8 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+
+        mainSplitPane.setDividerPosition(0, 1);
     }
 
     /**
@@ -167,8 +176,18 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Changes state of the UI based on type of command.
      */
-    @FXML
-    private void handleUiState(UiState uiState) {
+    private void handleUiState(CommandResult commandResult) {
+        UiState uiState = commandResult.getUiState();
+        if (uiState == UiState.SPECIFIC_DETAILS) {
+            mainSplitPane.setDividerPosition(0, 0.5);
+            DetailsDisplay detailsDisplay = new DetailsDisplay(commandResult.getPersonToView());
+            detailsDisplayPlaceholder.getChildren().clear();
+            detailsDisplayPlaceholder.getChildren().add(detailsDisplay.getRoot());
+            detailsDisplayPlaceholder.setVisible(true);
+        } else {
+            mainSplitPane.setDividerPosition(0, 1);
+            detailsDisplayPlaceholder.setVisible(false);
+        }
         personListPanel.updateUiState(uiState);
     }
 
@@ -195,7 +214,7 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            handleUiState(commandResult.getUiState());
+            handleUiState(commandResult);
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -37,6 +37,7 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public void updateUiState(UiState uiState) {
         this.uiState = uiState;
+        personListView.refresh();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/Ui.java
+++ b/src/main/java/seedu/address/ui/Ui.java
@@ -11,7 +11,7 @@ public interface Ui {
      * States of UI display.
      */
     public enum UiState {
-        DETAILS, TASKS
+        DETAILS, TASKS, SPECIFIC_DETAILS
     }
 
     /** Starts the UI (and the App).  */

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -132,6 +132,12 @@
     -fx-text-fill: #010504;
 }
 
+.custom-separator {
+    -fx-background-color: white;
+    -fx-padding: 0.001 0 0.001 0;
+    -fx-border-width: 1;
+}
+
 .stack-pane {
      -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/DetailsDisplay.fxml
+++ b/src/main/resources/view/DetailsDisplay.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.VBox?>
+
+<ScrollPane fitToWidth="true" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+    <VBox fillWidth="true" spacing="10">
+
+        <VBox spacing="10" styleClass="vbox-border">
+            <Label fx:id="name" styleClass="cell_big_label" text="\$first" wrapText="true"/>
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
+            <Label fx:id="emergencyContact" styleClass="cell_small_label" text="\$emergencyContact" wrapText="true"/>
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true" />
+            <FlowPane fx:id="subjects" />
+        </VBox>
+
+        <Separator styleClass="custom-separator" />
+
+        <VBox spacing="5" styleClass="vbox-border">
+            <Label styleClass="cell_big_label" text="Note" />
+            <Label fx:id="note" styleClass="cell_small_label" text="\$note" wrapText="true" />
+        </VBox>
+
+        <Separator styleClass="custom-separator" />
+
+        <VBox spacing="5" styleClass="vbox-border">
+            <Label styleClass="cell_big_label" text="Tasks" />
+            <Label fx:id="tasks" styleClass="cell_small_label" text="\$tasks" wrapText="true" />
+        </VBox>
+
+    </VBox>
+</ScrollPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,12 +46,10 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+        <SplitPane fx:id="mainSplitPane" dividerPositions="1" VBox.vgrow="ALWAYS">
+          <StackPane fx:id="personListPanelPlaceholder" minWidth="200" />
+          <StackPane fx:id="detailsDisplayPlaceholder" visible="false" /> <!-- Initially hidden -->
+        </SplitPane>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/PersonTaskCard.fxml
+++ b/src/main/resources/view/PersonTaskCard.fxml
@@ -3,7 +3,6 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,56 +14,65 @@ import seedu.address.ui.Ui.UiState;
 public class CommandResultTest {
     @Test
     public void equals() {
-        CommandResult commandResult = new CommandResult("feedback", UiState.DETAILS);
+        CommandResult commandResult1 = new CommandResult("feedback", UiState.DETAILS);
 
         // same values -> returns true
-        assertTrue(commandResult.equals(new CommandResult("feedback", UiState.DETAILS)));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult1.equals(new CommandResult("feedback", UiState.DETAILS)));
+        assertTrue(commandResult1.equals(new CommandResult("feedback", false, false)));
 
         // same object -> returns true
-        assertTrue(commandResult.equals(commandResult));
+        assertTrue(commandResult1.equals(commandResult1));
 
         // null -> returns false
-        assertFalse(commandResult.equals(null));
+        assertFalse(commandResult1.equals(null));
 
         // different types -> returns false
-        assertFalse(commandResult.equals(0.5f));
+        assertFalse(commandResult1.equals(0.5f));
 
         // different feedbackToUser value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("different", UiState.DETAILS)));
+        assertFalse(commandResult1.equals(new CommandResult("different", UiState.DETAILS)));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult1.equals(new CommandResult("feedback", true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult1.equals(new CommandResult("feedback", false, true)));
 
         // different uiState value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("different", UiState.TASKS)));
+        assertFalse(commandResult1.equals(new CommandResult("feedback", UiState.TASKS)));
+
+        // different personToView value -> returns false
+        CommandResult commandResult2 = new CommandResult("feedback", BOB);
+        assertFalse(commandResult2.equals(new CommandResult("feedback", AMY)));
     }
 
     @Test
     public void hashcode() {
-        CommandResult commandResult = new CommandResult("feedback", UiState.DETAILS);
+        CommandResult commandResult1 = new CommandResult("feedback", UiState.DETAILS);
 
         // same values -> returns same hashcode
-        assertEquals(commandResult.hashCode(), new CommandResult("feedback", UiState.DETAILS).hashCode());
+        assertEquals(commandResult1.hashCode(), new CommandResult("feedback", UiState.DETAILS).hashCode());
 
         // different feedbackToUser value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("different",
+        assertNotEquals(commandResult1.hashCode(), new CommandResult("different",
                 UiState.DETAILS).hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+        assertNotEquals(commandResult1.hashCode(), new CommandResult("feedback",
                 true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+        assertNotEquals(commandResult1.hashCode(), new CommandResult("feedback",
                 false, true).hashCode());
 
         // different uiState value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(),
+        assertNotEquals(commandResult1.hashCode(),
                 new CommandResult("feedback", UiState.TASKS).hashCode());
+
+        // different personToView value -> returns different hashcode
+        CommandResult commandResult2 = new CommandResult("feedback", BOB);
+        assertNotEquals(commandResult2.hashCode(),
+                new CommandResult("feedback", AMY).hashCode());
     }
 
     @Test
@@ -69,7 +80,8 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback", UiState.DETAILS);
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + ", uiState=" + commandResult.getUiState() + "}";
+                + ", exit=" + commandResult.isExit() + ", uiState=" + commandResult.getUiState()
+                + ", personToView=" + commandResult.getPersonToView() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -1,14 +1,21 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ViewCommand.
@@ -30,6 +37,35 @@ public class ViewCommandTest {
                 model.getAddressBook().getPersonList().get(0));
         assertCommandSuccess(new ViewCommand(model.getAddressBook().getPersonList().get(0).getName()),
                 model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonName_failure() {
+        Name invalidName = new Name("FancyPants");
+        ViewCommand viewCommand = new ViewCommand(invalidName);
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NAME);
+    }
+
+    @Test
+    public void equals() {
+        ViewCommand viewAmyCommand = new ViewCommand(AMY.getName());
+        ViewCommand viewBobCommand = new ViewCommand(BOB.getName());
+
+        // same object -> returns true
+        assertTrue(viewAmyCommand.equals(viewAmyCommand));
+
+        // same values -> returns true
+        ViewCommand viewAmyCommandCopy = new ViewCommand(AMY.getName());
+        assertTrue(viewAmyCommand.equals(viewAmyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewAmyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewAmyCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(viewAmyCommand.equals(viewBobCommand));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.ui.Ui.UiState;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ViewCommand.
@@ -26,10 +25,11 @@ public class ViewCommandTest {
 
     @Test
     public void execute_showsSameList() {
+        CommandResult expectedCommandResult = new CommandResult(String.format(ViewCommand.MESSAGE_VIEW_SUCCESS,
+                model.getAddressBook().getPersonList().get(0).getName()),
+                model.getAddressBook().getPersonList().get(0));
         assertCommandSuccess(new ViewCommand(model.getAddressBook().getPersonList().get(0).getName()),
-                model, String.format(ViewCommand.MESSAGE_VIEW_SUCCESS,
-                        model.getAddressBook().getPersonList().get(0).getName()),
-                UiState.SPECIFIC_DETAILS, expectedModel);
+                model, expectedCommandResult, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.ui.Ui.UiState;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ViewCommand.
+ */
+public class ViewCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_showsSameList() {
+        assertCommandSuccess(new ViewCommand(model.getAddressBook().getPersonList().get(0).getName()),
+                model, String.format(ViewCommand.MESSAGE_VIEW_SUCCESS,
+                        model.getAddressBook().getPersonList().get(0).getName()),
+                UiState.SPECIFIC_DETAILS, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -154,10 +154,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_view() throws Exception {
-        Person person = new PersonBuilder().build();
         ViewCommand command = (ViewCommand) parser.parseCommand(ViewCommand.COMMAND_WORD + " "
-                + person.getName());
-        assertEquals(new ViewCommand(person.getName()), command);
+                + NAME_DESC_AMY);
+        assertEquals(new ViewCommand(AMY.getName()), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -39,6 +39,7 @@ import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.commands.UpdateCommand.UpdatePersonDescriptor;
 import seedu.address.logic.commands.UpdateTaskCommand;
 import seedu.address.logic.commands.UpdateTaskCommand.UpdateTaskDescriptor;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.commands.ViewTasksCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelManager;
@@ -149,6 +150,14 @@ public class AddressBookParserTest {
     public void parseCommand_viewTasks() throws Exception {
         assertTrue(parser.parseCommand(ViewTasksCommand.COMMAND_WORD) instanceof ViewTasksCommand);
         assertTrue(parser.parseCommand(ViewTasksCommand.COMMAND_WORD + " 3") instanceof ViewTasksCommand);
+    }
+
+    @Test
+    public void parseCommand_view() throws Exception {
+        Person person = new PersonBuilder().build();
+        ViewCommand command = (ViewCommand) parser.parseCommand(ViewCommand.COMMAND_WORD + " "
+                + person.getName());
+        assertEquals(new ViewCommand(person.getName()), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ViewCommand;
+
+public class ViewCommandParserTest {
+    private ViewCommandParser parser = new ViewCommandParser();
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE);
+
+        // no name specified
+        assertParseFailure(parser, PHONE_DESC_AMY, expectedMessage);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPersons.AMY;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +13,12 @@ import seedu.address.logic.commands.ViewCommand;
 
 public class ViewCommandParserTest {
     private ViewCommandParser parser = new ViewCommandParser();
+
+    @Test
+    public void parse_nameSpecified_success() {
+        ViewCommand expectedCommand = new ViewCommand(AMY.getName());
+        assertParseSuccess(parser, NAME_DESC_AMY, expectedCommand);
+    }
 
     @Test
     public void parse_missingCompulsoryField_failure() {


### PR DESCRIPTION
There are only two type of UI layouts for person details: one excluding task list and one which only shows tasks.

It is not possible to view a specific student's details all at once, which is inconvenient if the tutor wants to view all details.

Let's introduce a command that allows viewing a specific student's details, splitting the screen so that there is more space for details, while still showing the list of students.

This allows more information to be shown at once, making efficient use of the UI space.

Resolves #76, resolves #77 