### PR TITLE
Fix invalid level reassignment for students

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -100,18 +100,15 @@ public class TagCommand extends Command {
                 .orElse(studentToTag.getEmergencyContact());
         Address updatedAddress = tagsToAdd.getAddress().orElse(studentToTag.getAddress());
         Note updatedNote = tagsToAdd.getNote().orElse(studentToTag.getNote());
-
         Level updatedLevel = tagsToAdd.getLevel().orElse(studentToTag.getLevel());
+        Set<Subject> updatedSubjects = tagsToAdd.getSubjects().orElse(studentToTag.getSubjects());
 
-        if (updatedLevel != null && tagsToAdd.getSubjects().isPresent()) {
+        if (updatedLevel != null && updatedSubjects != null) {
             if (!Subject.isValidSubjectsByLevel(updatedLevel,
-                            tagsToAdd
-                                .getSubjects()
-                                .get())) {
+                    updatedSubjects)) {
                 throw new CommandException(Subject.getValidSubjectMessage());
             }
         }
-        Set<Subject> updatedSubjects = tagsToAdd.getSubjects().orElse(studentToTag.getSubjects());
 
         TaskList updatedTaskList = tagsToAdd.getTaskList().orElse(studentToTag.getTaskList());
         Set<LessonTime> updatedLessonTimes = tagsToAdd.getLessonTimes()

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -103,7 +103,7 @@ public class TagCommand extends Command {
         Level updatedLevel = tagsToAdd.getLevel().orElse(studentToTag.getLevel());
         Set<Subject> updatedSubjects = tagsToAdd.getSubjects().orElse(studentToTag.getSubjects());
 
-        if (updatedLevel != null && updatedSubjects != null) {
+        if (!updatedSubjects.isEmpty()) {
             if (!Subject.isValidSubjectsByLevel(updatedLevel,
                     updatedSubjects)) {
                 throw new CommandException(Subject.getValidSubjectMessage());

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -106,8 +106,6 @@ public class UpdateCommand extends Command {
                                                 UpdateStudentDescriptor updateStudentDescriptor)
             throws CommandException {
 
-        assert studentToUpdate != null;
-
         Name updatedName = updateStudentDescriptor.getName().orElse(studentToUpdate.getName());
         Phone updatedPhone = updateStudentDescriptor.getPhone().orElse(studentToUpdate.getPhone());
         EmergencyContact updatedEmergencyContact = updateStudentDescriptor.getEmergencyContact()

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
@@ -104,7 +103,8 @@ public class UpdateCommand extends Command {
      * updated with {@code updateStudentDescriptor}.
      */
     private static Student createUpdatedStudent(Student studentToUpdate,
-                                                UpdateStudentDescriptor updateStudentDescriptor) {
+                                                UpdateStudentDescriptor updateStudentDescriptor)
+    throws CommandException {
         assert studentToUpdate != null;
 
         Name updatedName = updateStudentDescriptor.getName().orElse(studentToUpdate.getName());
@@ -114,15 +114,15 @@ public class UpdateCommand extends Command {
         Address updatedAddress = updateStudentDescriptor.getAddress().orElse(studentToUpdate.getAddress());
         Note updatedNote = updateStudentDescriptor.getNote().orElse(studentToUpdate.getNote());
         Level updatedLevel = updateStudentDescriptor.getLevel().orElse(studentToUpdate.getLevel());
-        if (updatedLevel != null && updateStudentDescriptor.getSubjects().isPresent()) {
-            checkArgument(
-                    Subject.isValidSubjectsByLevel(updatedLevel,
-                            updateStudentDescriptor
-                                    .getSubjects()
-                                    .get()),
-                    Subject.MESSAGE_LEVEL_NEEDED);
-        }
         Set<Subject> updatedSubjects = updateStudentDescriptor.getSubjects().orElse(studentToUpdate.getSubjects());
+
+        if (updatedLevel != null && updatedSubjects != null) {
+            if (!Subject.isValidSubjectsByLevel(updatedLevel,
+                    updatedSubjects)) {
+                throw new CommandException(Subject.getValidSubjectMessage());
+            }
+        }
+
         TaskList updatedTaskList = updateStudentDescriptor.getTaskList().orElse(studentToUpdate.getTaskList());
         Set<LessonTime> updatedLessonTimes = updateStudentDescriptor.getLessonTimes()
                 .orElse(studentToUpdate.getLessonTimes());

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -115,7 +115,7 @@ public class UpdateCommand extends Command {
         Level updatedLevel = updateStudentDescriptor.getLevel().orElse(studentToUpdate.getLevel());
         Set<Subject> updatedSubjects = updateStudentDescriptor.getSubjects().orElse(studentToUpdate.getSubjects());
 
-        if (updatedLevel != null && updatedSubjects != null) {
+        if (!updatedSubjects.isEmpty()) {
             if (!Subject.isValidSubjectsByLevel(updatedLevel,
                     updatedSubjects)) {
                 throw new CommandException(Subject.getValidSubjectMessage());

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -104,7 +104,8 @@ public class UpdateCommand extends Command {
      */
     private static Student createUpdatedStudent(Student studentToUpdate,
                                                 UpdateStudentDescriptor updateStudentDescriptor)
-    throws CommandException {
+            throws CommandException {
+
         assert studentToUpdate != null;
 
         Name updatedName = updateStudentDescriptor.getName().orElse(studentToUpdate.getName());

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Optional;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -136,6 +138,41 @@ public class TagCommandTest {
         TagCommand tagCommand = new TagCommand(invalidName, descriptor);
 
         assertCommandFailure(tagCommand, model, TagCommand.MESSAGE_STUDENT_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
+
+
+        Name studentInList = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased())
+                .getName();
+
+        //Ensures Student first has a Valid Level and Subject before making it invalid
+
+        UpdateStudentDescriptor test =
+                new UpdateStudentDescriptorBuilder()
+                        .withLevel("S2 NA")
+                        .withSubjects("Math")
+                        .build();
+        new TagCommand(studentInList, test).execute(model);
+
+        UpdateStudentDescriptor descriptor =
+                new UpdateStudentDescriptorBuilder()
+                        .withLevel("S3 Express")
+                        .build();
+
+        TagCommand tagCommand = new TagCommand(studentInList, descriptor);
+
+        String expectedMessage = "Subject is not valid for given level. "
+                + "Valid subjects for S3 EXPRESS: [A_MATH, E_MATH, PHYSICS, CHEMISTRY, "
+                + "BIOLOGY, COMBINED_SCIENCE, ACCOUNTING, LITERATURE, HISTORY, GEOGRAPHY, "
+                + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
+                + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
+
+        assertCommandFailure(tagCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -19,6 +19,7 @@ import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -172,7 +173,10 @@ public class TagCommandTest {
                 + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
                 + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
 
-        assertCommandFailure(tagCommand, model, expectedMessage);
+        CommandException thrown = Assertions.assertThrows(CommandException.class, () -> {
+            tagCommand.execute(model);
+        });
+        assertEquals(expectedMessage, thrown.getMessage());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -142,38 +142,33 @@ public class TagCommandTest {
     }
 
     @Test
-    public void execute_tagStudentWithNoSubjectsWithLevel() {
+    public void execute_tagStudentWithNoSubjectsWithLevel_success() {
+
+        //Remove subjects of student in address book
         Student studentInList = model.getAddressBook()
                 .getStudentList()
                 .get(INDEX_SECOND_STUDENT
                         .getZeroBased());
+        Student replaceStudent = new StudentBuilder(studentInList).withSubjects().build();
+        model.setStudent(studentInList, replaceStudent);
 
-        Student taggedStudent = new StudentBuilder(studentInList).withSubjects().build();
-
-        System.out.println(studentInList);
-        System.out.println(taggedStudent);
-
-        model.setStudent(studentInList, taggedStudent);
-
-        Student test = model.getAddressBook()
+        //Get new student for expected message
+        Student newStudent = model.getAddressBook()
                 .getStudentList()
                 .get(INDEX_SECOND_STUDENT
                         .getZeroBased());
 
-        Name testName = test.getName();
+        Name studentName = newStudent.getName();
 
-        System.out.println(test);
-
-        Student finalRest = new StudentBuilder(test).withLevel("S3 NA").build();
+        //Student after being updated with new Level
+        Student finalStudent = new StudentBuilder(newStudent).withLevel("S3 NA").build();
 
         UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withLevel("S3 NA").build();
-        TagCommand testTagCommand = new TagCommand(testName, descriptor);
+        TagCommand tagCommand = new TagCommand(studentName, descriptor);
         String expectedMessage = String.format(TagCommand.MESSAGE_TAG_STUDENT_SUCCESS,
-                Messages.format(finalRest));
+                Messages.format(finalStudent));
 
-
-        assertCommandSuccess(testTagCommand, model, expectedMessage, UiState.DETAILS, model);
-
+        assertCommandSuccess(tagCommand, model, expectedMessage, UiState.DETAILS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -142,6 +142,41 @@ public class TagCommandTest {
     }
 
     @Test
+    public void execute_tagStudentWithNoSubjectsWithLevel() {
+        Student studentInList = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased());
+
+        Student taggedStudent = new StudentBuilder(studentInList).withSubjects().build();
+
+        System.out.println(studentInList);
+        System.out.println(taggedStudent);
+
+        model.setStudent(studentInList, taggedStudent);
+
+        Student test = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased());
+
+        Name testName = test.getName();
+
+        System.out.println(test);
+
+        Student finalRest = new StudentBuilder(test).withLevel("S3 NA").build();
+
+        UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withLevel("S3 NA").build();
+        TagCommand testTagCommand = new TagCommand(testName, descriptor);
+        String expectedMessage = String.format(TagCommand.MESSAGE_TAG_STUDENT_SUCCESS,
+                Messages.format(finalRest));
+
+
+        assertCommandSuccess(testTagCommand, model, expectedMessage, UiState.DETAILS, model);
+
+    }
+
+    @Test
     public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
 
 

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
@@ -198,7 +199,10 @@ public class UpdateCommandTest {
                 + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
                 + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
 
-        assertCommandFailure(updateCommand, model, expectedMessage);
+        CommandException thrown = assertThrows(CommandException.class, () -> {
+            updateCommand.execute(model);
+        });
+        assertEquals(expectedMessage, thrown.getMessage());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -164,6 +165,40 @@ public class UpdateCommandTest {
                 new UpdateStudentDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(updateCommand, model, Messages.MESSAGE_INVALID_STUDENT_UPDATE);
+    }
+
+    @Test
+    public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
+
+
+        Name studentInList = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased())
+                .getName();
+
+        //Ensures Student first has a Valid Level and Subject before making it invalid
+        UpdateStudentDescriptor test =
+                new UpdateStudentDescriptorBuilder()
+                        .withLevel("S2 NA")
+                        .withSubjects("Math")
+                        .build();
+        new TagCommand(studentInList, test).execute(model);
+
+        UpdateStudentDescriptor descriptor =
+                new UpdateStudentDescriptorBuilder()
+                        .withLevel("S3 Express")
+                        .build();
+
+        UpdateCommand updateCommand = new UpdateCommand(studentInList, descriptor);
+
+        String expectedMessage = "Subject is not valid for given level. "
+                + "Valid subjects for S3 EXPRESS: [A_MATH, E_MATH, PHYSICS, CHEMISTRY, "
+                + "BIOLOGY, COMBINED_SCIENCE, ACCOUNTING, LITERATURE, HISTORY, GEOGRAPHY, "
+                + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
+                + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
+
+        assertCommandFailure(updateCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -171,7 +171,6 @@ public class UpdateCommandTest {
     @Test
     public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
 
-
         Name studentInList = model.getAddressBook()
                 .getStudentList()
                 .get(INDEX_SECOND_STUDENT

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -169,6 +169,36 @@ public class UpdateCommandTest {
     }
 
     @Test
+    public void execute_updateStudentWithNoSubjectsWithLevel_success() {
+
+        //Remove subjects of student in address book
+        Student studentInList = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased());
+        Student replaceStudent = new StudentBuilder(studentInList).withSubjects().build();
+        model.setStudent(studentInList, replaceStudent);
+
+        //Get new student for expected message
+        Student newStudent = model.getAddressBook()
+                .getStudentList()
+                .get(INDEX_SECOND_STUDENT
+                        .getZeroBased());
+
+        Name studentName = newStudent.getName();
+
+        //Student after being updated with new Level
+        Student finalStudent = new StudentBuilder(newStudent).withLevel("S3 NA").build();
+
+        UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withLevel("S3 NA").build();
+        UpdateCommand updateCommand = new UpdateCommand(studentName, descriptor);
+        String expectedMessage = String.format(UpdateCommand.MESSAGE_UPDATE_STUDENT_SUCCESS,
+                Messages.format(finalStudent));
+
+        assertCommandSuccess(updateCommand, model, expectedMessage, UiState.DETAILS, model);
+    }
+
+    @Test
     public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
 
         Name studentInList = model.getAddressBook()


### PR DESCRIPTION
1. Throwing a Command Exception instead of checkArgument ensures that the error message is correctly displayed. 

2. Checking for Level validity after Subjects ensures that the new Level validity can be checked even if student already has Subjects

close #155, close #152, close #151, close #124