### PR TITLE
Fix AddCommand bugs and add more tests

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -735,6 +735,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 11. Should not depend on the developer's own remote server.
 12. GUI should work well for standard screen resolutions 1920x1080 and higher and for screen scales 100% and 125%.
 
+***
 
 ### Glossary
 
@@ -772,6 +773,8 @@ testers are expected to do more *exploratory* testing.
     2. Re-launch the app by double-clicking the jar file.<br>
        Expected: The most recent window size and location is retained.
 
+***
+
 ### Deleting a student
 
 1. Deleting a student while all students are being shown
@@ -787,13 +790,15 @@ testers are expected to do more *exploratory* testing.
     4. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
        Expected: Similar to previous.
 
+***
+
 ### Finding specific students
 
 1. Finding specific students while all students are being shown
 
     1. Prerequisites: List all students using the `list` command. Multiple students in the list with varying names, levels and subjects.
 
-    2. Valid Test Cases
+    2. **Valid Test Cases**
 
         1. Find by name:`find n/Alex`<br>
            Expected: Only students with the name `Alex` are displayed. Number of students found is reflected in the status message.
@@ -804,9 +809,9 @@ testers are expected to do more *exploratory* testing.
         3. Find by subject: `find s/MATH`<br>
            Expected: Only students tagged with the subject `MATH` are displayed. Number of students found is reflected in the status message.
 
-    3. Invalid Test Cases
+    3. **Invalid Test Cases**
 
-       1. Find by name:`find n/!@!`, `find n/1234`, `...`<br>
+       1. Find by name:`find n/!@!`, `find n/1e12#>`, `...`<br>
           Expected: All students still listed. Error details shown in the status message. Status bar remains the same.
 
        2. Find by level and track: `find l/S1` (no track entered), `find l/IP` (no level entered), `...`<br>

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -37,9 +37,8 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMERGENCY_CONTACT + "93838420 "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_LEVEL + "S3 NA "
-            + PREFIX_SUBJECT + "A_MATH "
-            + PREFIX_SUBJECT + "CHEMISTRY "
+            + PREFIX_LEVEL + "S1 NT "
+            + PREFIX_SUBJECT + "MATH "
             + PREFIX_LESSON_TIME + "SUN-11:00-13:00";
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -37,8 +37,8 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMERGENCY_CONTACT + "93838420 "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_LEVEL + "P5 "
-            + PREFIX_SUBJECT + "MATH "
+            + PREFIX_LEVEL + "S3 NA "
+            + PREFIX_SUBJECT + "A_MATH "
             + PREFIX_SUBJECT + "CHEMISTRY "
             + PREFIX_LESSON_TIME + "SUN-11:00-13:00";
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -30,7 +30,6 @@ import seedu.address.model.student.task.TaskList;
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -47,7 +46,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         //Parse all arguments
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS,
+                PREFIX_LEVEL);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         EmergencyContact emergencyContact = ParserUtil
@@ -62,13 +62,21 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (argMultimap.getValue(PREFIX_LEVEL).isPresent()) {
             level = ParserUtil.parseLevel(argMultimap.getValue(PREFIX_LEVEL).get());
         }
+
         Set<Subject> subjectList = new HashSet<>();
         if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
             if (argMultimap.getValue(PREFIX_LEVEL).isEmpty()) {
                 throw new ParseException(Subject.MESSAGE_LEVEL_NEEDED);
             }
-            subjectList = ParserUtil.parseSubjectsByLevel(level, argMultimap.getAllValues(PREFIX_SUBJECT));
+
+            subjectList = ParserUtil.parseSubjects(argMultimap.getAllValues(PREFIX_SUBJECT));
+
+            if (!Subject.isValidSubjectsByLevel(level,
+                    subjectList)) {
+                throw new ParseException(Subject.getValidSubjectMessage());
+            }
         }
+
         Set<LessonTime> lessonTimes = ParserUtil.parseLessonTimes(argMultimap.getAllValues(PREFIX_LESSON_TIME));
 
         Student student = new Student(name, phone, emergencyContact, address, note, subjectList,
@@ -76,7 +84,4 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         return new AddCommand(student);
     }
-
-
-
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -174,7 +174,7 @@ public class ParserUtil {
         requireNonNull(subject);
         String trimmedSubject = subject.trim();
         if (!Subject.isValidSubjectNameByLevel(level, trimmedSubject)) {
-            throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Subject.getValidSubjectMessage());
         }
         return new Subject(trimmedSubject);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -165,34 +165,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String subject} into a {@code Subject}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code subject} is invalid.
-     */
-    public static Subject parseSubjectByLevel(Level level, String subject) throws ParseException {
-        requireNonNull(subject);
-        String trimmedSubject = subject.trim();
-        if (!Subject.isValidSubjectNameByLevel(level, trimmedSubject)) {
-            throw new ParseException(Subject.getValidSubjectMessage());
-        }
-        return new Subject(trimmedSubject);
-    }
-
-    /**
-     * Parses {@code Collection<String> subjects} into a {@code Set<Subject>}.
-     */
-    public static Set<Subject> parseSubjectsByLevel(Level level, Collection<String> subjects) throws ParseException {
-        requireNonNull(level);
-        requireNonNull(subjects);
-        final Set<Subject> subjectSet = new HashSet<>();
-        for (String subjectName : subjects) {
-            subjectSet.add(parseSubjectByLevel(level, subjectName));
-        }
-        return subjectSet;
-    }
-
-    /**
      * Parses a {@code String desc} into an {@code TaskDescription}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
@@ -51,7 +51,8 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS,
+                PREFIX_LEVEL);
 
         UpdateStudentDescriptor updateStudentDescriptor = new UpdateStudentDescriptor();
 

--- a/src/main/java/seedu/address/model/student/Level.java
+++ b/src/main/java/seedu/address/model/student/Level.java
@@ -63,6 +63,11 @@ public class Level {
         requireNonNull(year);
         requireNonNull(track);
 
+        // Check for NONE NONE as a valid input, but disallow other combinations with NONE
+        if (year.equals("NONE") || track.equals("NONE")) {
+            return year.equals("NONE") && track.equals("NONE");
+        }
+
         if (year.equalsIgnoreCase("S5")) {
             return track.equalsIgnoreCase("NA");
         }

--- a/src/main/java/seedu/address/model/student/Subject.java
+++ b/src/main/java/seedu/address/model/student/Subject.java
@@ -73,6 +73,8 @@ public class Subject {
      * Constructs a {@code Subject}.
      *
      * @param subjectName A valid subject name.
+     * @throws NullPointerException if subjectName is null.
+     * @throws IllegalArgumentException if subjectName is invalid.
      */
     public Subject(String subjectName) {
         requireNonNull(subjectName);
@@ -81,7 +83,11 @@ public class Subject {
     }
 
     /**
-     * Returns true if a given string is a valid subject name and correspondences to the correct level.
+     * Checks if a subject name is valid for a given level.
+     *
+     * @param level The level to validate against.
+     * @param subjectName The subject name to validate.
+     * @return true if subjectName is valid for the specified level, false otherwise.
      */
     public static boolean isValidSubjectNameByLevel(Level level, String subjectName) {
         requireNonNull(subjectName);
@@ -93,12 +99,37 @@ public class Subject {
                 .contains(Subjects.valueOf(subjectName.toUpperCase()));
     }
 
+    /**
+     * Retrieves the last generated validation message for valid subjects by level.
+     *
+     * @return The current validation message.
+     */
     public static String getValidSubjectMessage() {
         return messageValidSubjectsByLevel;
     }
 
     /**
-     * Returns true if a given string is a valid subject name.
+     * Retrieves the valid subject message for a given level.
+     *
+     * @param level The level for which to get valid subjects.
+     * @return A message listing valid subjects for the level, or a message indicating a level is required.
+     */
+    public static String getValidSubjectMessage(Level level) {
+        if (level == null || level.levelName.equals("NONE NONE")) {
+            return Subject.MESSAGE_LEVEL_NEEDED;
+        }
+
+        EnumSet<Subjects> validSubjects = validSubjectsByLevel.get(level);
+        messageValidSubjectsByLevel = String.format("%s %s: %s",
+                MESSAGE_VALID_SUBJECTS_BASE, level, validSubjects);
+        return messageValidSubjectsByLevel;
+    }
+
+    /**
+     * Checks if a given string is a valid subject name.
+     *
+     * @param subjectName The subject name to validate.
+     * @return true if subjectName is valid, false otherwise.
      */
     public static boolean isValidSubjectName(String subjectName) {
         requireNonNull(subjectName);
@@ -106,15 +137,19 @@ public class Subject {
     }
 
     /**
-     * Returns true if all subjects are valid according to the given level
-     * */
+     * Checks if all subjects in a set are valid for a given level.
+     *
+     * @param level The level to validate against.
+     * @param subjects A set of subjects to validate.
+     * @return true if all subjects are valid for the specified level, false otherwise.
+     */
     public static boolean isValidSubjectsByLevel(Level level, Set<Subject> subjects) {
         if (level == null || level.levelName.equals("NONE NONE")) {
             messageValidSubjectsByLevel = Subject.MESSAGE_LEVEL_NEEDED;
             return false;
         }
         EnumSet<Subjects> validSubjects = validSubjectsByLevel.get(level);
-        for (Subject s: subjects) {
+        for (Subject s : subjects) {
             if (!validSubjects.contains(Subjects.valueOf(s.subjectName))) {
                 messageValidSubjectsByLevel = String.format("%s %s: %s",
                         MESSAGE_VALID_SUBJECTS_BASE, level, validSubjects);
@@ -125,6 +160,12 @@ public class Subject {
         return true;
     }
 
+    /**
+     * Compares this subject to the specified object for equality.
+     *
+     * @param other The object to compare to.
+     * @return true if the specified object is equal to this subject, false otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -140,13 +181,20 @@ public class Subject {
         return subjectName.equals(otherSubject.subjectName);
     }
 
+    /**
+     * Returns the hash code for this subject.
+     *
+     * @return The hash code value of this subject.
+     */
     @Override
     public int hashCode() {
         return subjectName.hashCode();
     }
 
     /**
-     * Format state as text for viewing.
+     * Formats this subject as a string for viewing.
+     *
+     * @return A string representation of this subject.
      */
     public String toString() {
         return '[' + subjectName + ']';

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -59,7 +59,8 @@ public class CommandTestUtil {
     public static final String VALID_TASK_DEADLINE = "2024-10-15";
     public static final String VALID_TASK_DEADLINE_AMY = "2024-01-01";
     public static final String VALID_TASK_INDEX = "1";
-    public static final String VALID_LESSON_TIME = "SUN-11:00-13:00";
+    public static final String VALID_LESSON_TIME_SUN = "SUN-11:00-13:00";
+    public static final String VALID_LESSON_TIME_TUE = "TUE-00:00-02:00";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -81,7 +82,8 @@ public class CommandTestUtil {
     public static final String TASK_DEADLINE_DESC_AMY = " " + PREFIX_TASK_DEADLINE + VALID_TASK_DEADLINE_AMY;
     public static final String TASK_DEADLINE_DESC_BOB = " " + PREFIX_TASK_DEADLINE + VALID_TASK_DEADLINE;
     public static final String TASK_INDEX_DESC = " " + PREFIX_TASK_INDEX + VALID_TASK_INDEX;
-    public static final String LESSON_TIME_DESC = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME;
+    public static final String LESSON_TIME_SUN_DESC = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_SUN;
+    public static final String LESSON_TIME_TUE_DESC = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_TUE;
     public static final String INVALID_SUBJECT = "MATH*";
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/UpdateStudentDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateStudentDescriptorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_MATH;
@@ -54,7 +54,7 @@ public class UpdateStudentDescriptorTest {
         updatedAmy = new UpdateStudentDescriptorBuilder(DESC_AMY).withSubjects(VALID_SUBJECT_MATH).build();
         assertFalse(DESC_AMY.equals(updatedAmy));
 
-        updatedAmy = new UpdateStudentDescriptorBuilder(DESC_AMY).withLessonTimes(VALID_LESSON_TIME).build();
+        updatedAmy = new UpdateStudentDescriptorBuilder(DESC_AMY).withLessonTimes(VALID_LESSON_TIME_SUN).build();
         assertFalse(DESC_AMY.equals(updatedAmy));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -7,10 +7,15 @@ import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DES
 import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMERGENCY_CONTACT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LESSON_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_TUE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_NA;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -20,12 +25,16 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_TUE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_MATH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -38,6 +47,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.student.Address;
+import seedu.address.model.student.LessonTime;
+import seedu.address.model.student.Level;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Phone;
 import seedu.address.model.student.Student;
@@ -56,21 +67,52 @@ public class AddCommandParserTest {
                 + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
                 + ADDRESS_DESC_BOB + LEVEL_DESC_S1_EXPRESS + SUBJECT_DESC_ENGLISH, new AddCommand(expectedStudent));
 
+        // multiple spaces in name
+        expectedStudent = new StudentBuilder(BOB).withName("Bob    Choo  ").withSubjects(VALID_SUBJECT_ENGLISH).build();
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB
+                + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S1_EXPRESS + SUBJECT_DESC_ENGLISH, new AddCommand(expectedStudent));
+
+        // different casing in name
+        expectedStudent = new StudentBuilder(BOB).withName("bOB cHOo").withSubjects(VALID_SUBJECT_ENGLISH).build();
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB
+                + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S1_EXPRESS + SUBJECT_DESC_ENGLISH, new AddCommand(expectedStudent));
+
+        // multiple spaces and different casing in name
+        expectedStudent = new StudentBuilder(BOB).withName("bOB    cHOo   ")
+                .withSubjects(VALID_SUBJECT_ENGLISH).build();
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB
+                + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S1_EXPRESS + SUBJECT_DESC_ENGLISH, new AddCommand(expectedStudent));
+
+        // with valid level NONE NONE
+        expectedStudent = new StudentBuilder(BOB).withSubjects().withLevel("NONE NONE").build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB + ADDRESS_DESC_BOB ,
+                new AddCommand(expectedStudent));
 
         // multiple subjects - all accepted
-        Student expectedStudentMultipleSubjects = new StudentBuilder(BOB)
-                .withSubjects(VALID_SUBJECT_ENGLISH, VALID_SUBJECT_MATH)
-                .build();
+        expectedStudent = new StudentBuilder(BOB).withSubjects(VALID_SUBJECT_ENGLISH, VALID_SUBJECT_MATH).build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
                         + LEVEL_DESC_S1_EXPRESS + ADDRESS_DESC_BOB + SUBJECT_DESC_MATH + SUBJECT_DESC_ENGLISH,
-                new AddCommand(expectedStudentMultipleSubjects));
+                new AddCommand(expectedStudent));
+
+        // multiple lesson times - all accepted
+        expectedStudent = new StudentBuilder(BOB).withSubjects(VALID_SUBJECT_ENGLISH)
+                .withLessonTimes(VALID_LESSON_TIME_SUN, VALID_LESSON_TIME_TUE).build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                        + LEVEL_DESC_S1_EXPRESS + ADDRESS_DESC_BOB + SUBJECT_DESC_ENGLISH
+                        + LESSON_TIME_SUN_DESC + LESSON_TIME_TUE_DESC,
+                new AddCommand(expectedStudent));
     }
 
     @Test
-    public void parse_repeatedNonSubjectValue_failure() {
+    public void parse_repeatedNonSubjectNonLessonTimeValue_failure() {
         String validExpectedStudentString = NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
-                + ADDRESS_DESC_BOB + SUBJECT_DESC_ENGLISH;
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S1_NA + SUBJECT_DESC_ENGLISH;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedStudentString,
@@ -84,11 +126,18 @@ public class AddCommandParserTest {
         assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedStudentString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
+        // multiple emergency contacts
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_AMY + validExpectedStudentString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMERGENCY_CONTACT));
+
+        // multiple levels
+        assertParseFailure(parser, LEVEL_DESC_S4_NT + validExpectedStudentString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LEVEL));
+
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedStudentString + PHONE_DESC_AMY + EMERGENCY_CONTACT_DESC_AMY
-                        + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedStudentString,
+                        + NAME_DESC_AMY + ADDRESS_DESC_AMY,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS,
                         PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT));
 
@@ -113,7 +162,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, validExpectedStudentString + INVALID_NAME_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
-
         // invalid phone
         assertParseFailure(parser, validExpectedStudentString + INVALID_PHONE_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
@@ -127,6 +175,18 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero subjects
         Student expectedStudent = new StudentBuilder(AMY).withSubjects().withLevel("NONE NONE").build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
+                        + EMERGENCY_CONTACT_DESC_AMY + ADDRESS_DESC_AMY,
+                new AddCommand(expectedStudent));
+
+        // zero lesson times
+        expectedStudent = new StudentBuilder(AMY).withSubjects().withLevel("NONE NONE").withLessonTimes().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
+                        + EMERGENCY_CONTACT_DESC_AMY + ADDRESS_DESC_AMY,
+                new AddCommand(expectedStudent));
+
+        // zero level
+        expectedStudent = new StudentBuilder(AMY).withLevel("").withSubjects().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY
                         + EMERGENCY_CONTACT_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedStudent));
@@ -178,6 +238,27 @@ public class AddCommandParserTest {
         // adding student with subject without level
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
                 + ADDRESS_DESC_BOB + INVALID_SUBJECT_DESC + VALID_SUBJECT_ENGLISH, Subject.MESSAGE_LEVEL_NEEDED);
+
+        // adding student with incorrect level S5 EXPRESS
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + " l/S5 EXPRESS", Level.MESSAGE_CONSTRAINTS);
+
+        // adding student with incorrect level S2 NONE
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + " l/S2 NONE", Level.MESSAGE_CONSTRAINTS);
+
+        // adding student with incorrect level NONE IP
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + " l/NONE IP", Level.MESSAGE_CONSTRAINTS);
+
+        // adding student with level but with an incorrect subject
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S4_NT + SUBJECT_DESC_MATH,
+                Subject.getValidSubjectMessage(new Level(VALID_LEVEL_S4_NT)));
+
+        // adding student with invalid lesson time
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + INVALID_LESSON_TIME_DESC, LessonTime.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -125,7 +125,7 @@ public class UpdateCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = VALID_NAME_AMY + PHONE_DESC_BOB + SUBJECT_DESC_MATH
+        String userInput = PHONE_DESC_BOB + SUBJECT_DESC_MATH
                 + ADDRESS_DESC_AMY + NAME_DESC_AMY + SUBJECT_DESC_ENGLISH + LESSON_TIME_SUN_DESC;
 
         UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -133,7 +133,19 @@ public class UpdateCommandParserTest {
                 .withSubjects(VALID_SUBJECT_MATH, VALID_SUBJECT_ENGLISH).withLessonTimes(VALID_LESSON_TIME_SUN).build();
         UpdateCommand expectedCommand = new UpdateCommand(new Name(VALID_NAME_AMY), descriptor);
 
-        assertParseSuccess(parser, userInput, expectedCommand);
+        assertParseSuccess(parser, VALID_NAME_AMY + userInput, expectedCommand);
+
+        // multiple spaces in name
+        String multiSpaceName = "Amy   Bee   ";
+        assertParseSuccess(parser, multiSpaceName + userInput, expectedCommand);
+
+        // different casing in name
+        String differentCasingName = "AmY bEe";
+        assertParseSuccess(parser, differentCasingName + userInput, expectedCommand);
+
+        // multiple spaces and different casing in name
+        String validName = "   aMy    BEe  ";
+        assertParseSuccess(parser, validName + userInput, expectedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_LEVEL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -17,7 +17,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
@@ -112,10 +112,10 @@ public class UpdateCommandParserTest {
         // while parsing {@code PREFIX_LESSON_TIME} alone will reset the
         // LessonTimes of the {@code Student} being updated,
         // parsing it together with a valid LessonTime results in error
-        assertParseFailure(parser, VALID_NAME_AMY + LESSON_TIME_DESC
+        assertParseFailure(parser, VALID_NAME_AMY + LESSON_TIME_SUN_DESC
                 + LESSONTIME_EMPTY, LessonTime.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, VALID_NAME_AMY + LESSONTIME_EMPTY
-                + LESSON_TIME_DESC, LessonTime.MESSAGE_CONSTRAINTS);
+                + LESSON_TIME_SUN_DESC, LessonTime.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, VALID_NAME_AMY + INVALID_NAME_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
@@ -125,11 +125,11 @@ public class UpdateCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         String userInput = VALID_NAME_AMY + PHONE_DESC_BOB + SUBJECT_DESC_MATH
-                + ADDRESS_DESC_AMY + NAME_DESC_AMY + SUBJECT_DESC_ENGLISH + LESSON_TIME_DESC;
+                + ADDRESS_DESC_AMY + NAME_DESC_AMY + SUBJECT_DESC_ENGLISH + LESSON_TIME_SUN_DESC;
 
         UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withAddress(VALID_ADDRESS_AMY)
-                .withSubjects(VALID_SUBJECT_MATH, VALID_SUBJECT_ENGLISH).withLessonTimes(VALID_LESSON_TIME).build();
+                .withSubjects(VALID_SUBJECT_MATH, VALID_SUBJECT_ENGLISH).withLessonTimes(VALID_LESSON_TIME_SUN).build();
         UpdateCommand expectedCommand = new UpdateCommand(new Name(VALID_NAME_AMY), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -174,8 +174,8 @@ public class UpdateCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // lesson times
-        userInput = targetName + LESSON_TIME_DESC;
-        descriptor = new UpdateStudentDescriptorBuilder().withLessonTimes(VALID_LESSON_TIME).build();
+        userInput = targetName + LESSON_TIME_SUN_DESC;
+        descriptor = new UpdateStudentDescriptorBuilder().withLessonTimes(VALID_LESSON_TIME_SUN).build();
         expectedCommand = new UpdateCommand(targetName, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_NA;
 import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -27,6 +28,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_ENGLISH
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_MATH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -46,7 +48,6 @@ import seedu.address.model.student.Subject;
 import seedu.address.testutil.UpdateStudentDescriptorBuilder;
 
 public class UpdateCommandParserTest {
-
     private static final String SUBJECT_EMPTY = " " + PREFIX_SUBJECT;
     private static final String LESSONTIME_EMPTY = " " + PREFIX_LESSON_TIME;
 
@@ -189,7 +190,7 @@ public class UpdateCommandParserTest {
     @Test
     public void parse_multipleRepeatedFields_failure() {
         // More extensive testing of duplicate parameter detections is done in
-        // AddCommandParserTest#parse_repeatedNonSubjectValue_failure()
+        // AddCommandParserTest#parse_repeatedNonSubjectNonLessonTimeValue_failure()
 
         // valid followed by invalid
         Name targetName = new Name(VALID_NAME_AMY);
@@ -199,8 +200,11 @@ public class UpdateCommandParserTest {
 
         // invalid followed by valid
         userInput = targetName + PHONE_DESC_BOB + INVALID_PHONE_DESC;
-
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // multiple levels repeated
+        userInput = targetName + LEVEL_DESC_S1_NA + LEVEL_DESC_S4_NT;
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LEVEL));
 
         // multiple valid fields repeated
         userInput = targetName + PHONE_DESC_AMY + ADDRESS_DESC_AMY

--- a/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
@@ -90,6 +90,21 @@ public class UpdateTaskCommandParserTest {
                 new UpdateTaskCommand(new Name(VALID_NAME_AMY), Index.fromOneBased(1), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
+
+        // multiple spaces in name
+        String multiSpaceName = " " + PREFIX_NAME + "Amy   Bee   ";
+        userInput = multiSpaceName + TASK_INDEX_DESC + TASK_DESCRIPTION_DESC_AMY + TASK_DEADLINE_DESC_AMY;
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // different casing in name
+        String differentCasingName = " " + PREFIX_NAME + "AMY bEe";
+        userInput = differentCasingName + TASK_INDEX_DESC + TASK_DESCRIPTION_DESC_AMY + TASK_DEADLINE_DESC_AMY;
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // multiple spaces and different casing in name
+        String validName = " " + PREFIX_NAME + "   AmY    bEE  ";
+        userInput = validName + TASK_INDEX_DESC + TASK_DESCRIPTION_DESC_AMY + TASK_DEADLINE_DESC_AMY;
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/LevelTest.java
+++ b/src/test/java/seedu/address/model/student/LevelTest.java
@@ -31,7 +31,12 @@ public class LevelTest {
         assertFalse(Level.isValidLevelName("^")); // only non-alphanumeric characters
         assertFalse(Level.isValidLevelName("s!gm4")); // contains non-alphanumeric characters
         assertFalse(Level.isValidLevelName("S5 EXPRESS"));
+        assertFalse(Level.isValidLevelName("S1 NONE"));
+        assertFalse(Level.isValidLevelName("NONE EXPRESS"));
+
         // valid levels
+        assertTrue(Level.isValidLevelName("NONE NONE"));
+
         assertTrue(Level.isValidLevelName("S1 EXPRESS"));
         assertTrue(Level.isValidLevelName("S2 EXPRESS"));
         assertTrue(Level.isValidLevelName("S3 EXPRESS"));

--- a/src/test/java/seedu/address/model/student/NameTest.java
+++ b/src/test/java/seedu/address/model/student/NameTest.java
@@ -46,6 +46,20 @@ public class NameTest {
     }
 
     @Test
+    public void different_spacing_test() {
+        assertTrue((new Name("Valid      Name")).toString().equals("Valid Name"));
+        assertTrue((new Name("Valid Name       ")).toString().equals("Valid Name"));
+        assertTrue((new Name("Valid       Name     ")).toString().equals("Valid Name"));
+    }
+
+    @Test
+    public void differentCasingAndSpacingTest() {
+        assertTrue((new Name("VaLId    nAme")).toString().equals("Valid Name"));
+        assertTrue((new Name("ValiD NaME       ")).toString().equals("Valid Name"));
+        assertTrue((new Name("VALID       NamE     ")).toString().equals("Valid Name"));
+    }
+
+    @Test
     public void equals() {
         Name name = new Name("Valid Name");
 

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -99,7 +99,7 @@ public class StudentTest {
         assertFalse(ALICE.equals(updatedAlice));
 
         // different lesson time -> returns false
-        updatedAlice = new StudentBuilder(ALICE).withLessonTimes(VALID_LESSON_TIME).build();
+        updatedAlice = new StudentBuilder(ALICE).withLessonTimes(VALID_LESSON_TIME_SUN).build();
         assertFalse(ALICE.equals(updatedAlice));
 
         // different subjects -> returns false

--- a/src/test/java/seedu/address/model/student/SubjectTest.java
+++ b/src/test/java/seedu/address/model/student/SubjectTest.java
@@ -65,11 +65,41 @@ public class SubjectTest {
     @Test
     public void isValidSubjectsByLevel_invalidLevel_failure() {
         assertFalse(Subject.isValidSubjectsByLevel(new Level("NONE NONE"), SUBJECT_ARRAY));
+        assertFalse(Subject.isValidSubjectsByLevel(null, SUBJECT_ARRAY));
     }
 
     @Test
     public void subject_case_insensitive() {
         assertTrue(new Subject("MATH").equals(new Subject("math")));
+    }
+
+    @Test
+    public void getValidSubjectMessage_invalidLevel_failure() {
+        assertEquals(Subject.getValidSubjectMessage(new Level("NONE NONE")), Subject.MESSAGE_LEVEL_NEEDED);
+        assertEquals(Subject.getValidSubjectMessage(null), Subject.MESSAGE_LEVEL_NEEDED);
+    }
+
+    @Test
+    public void equals() {
+        Subject math = new Subject("MATH");
+
+        // same values -> returns true
+        assertTrue(math.equals(new Subject("MATH")));
+
+        // same object -> returns true
+        assertTrue(math.equals(math));
+
+        // null -> returns false
+        assertFalse(math.equals(null));
+
+        // different types -> returns false
+        assertFalse(math.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(math.equals(new Subject("Chinese")));
+
+        // case-insensitive -> return true
+        assertTrue(math.equals(new Subject("math")));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/SubjectTest.java
+++ b/src/test/java/seedu/address/model/student/SubjectTest.java
@@ -74,9 +74,27 @@ public class SubjectTest {
     }
 
     @Test
-    public void getValidSubjectMessage_invalidLevel_failure() {
+    public void getValidSubjectMessage_invalidLevel() {
         assertEquals(Subject.getValidSubjectMessage(new Level("NONE NONE")), Subject.MESSAGE_LEVEL_NEEDED);
         assertEquals(Subject.getValidSubjectMessage(null), Subject.MESSAGE_LEVEL_NEEDED);
+    }
+
+    @Test
+    public void getValidSubjectMessage_validLevel() {
+        String expectedMessageUpperSec = "Subject is not valid for given level. "
+                + "Valid subjects for %s: [A_MATH, E_MATH, PHYSICS, CHEMISTRY, "
+                + "BIOLOGY, COMBINED_SCIENCE, ACCOUNTING, LITERATURE, HISTORY, GEOGRAPHY, "
+                + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
+                + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
+        String expectedMessageLowerSec = "Subject is not valid for given level. "
+                + "Valid subjects for %s: [MATH, SCIENCE, PHYSICS, CHEMISTRY, BIOLOGY, LITERATURE, HISTORY, "
+                + "GEOGRAPHY, SOCIAL_STUDIES, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, HIGHER_MALAY, TAMIL, "
+                + "HIGHER_TAMIL, HINDI]";
+
+        assertEquals(Subject.getValidSubjectMessage(new Level("S3 IP")),
+                String.format(expectedMessageUpperSec, "S3 IP"));
+        assertEquals(Subject.getValidSubjectMessage(new Level("S1 NT")),
+                String.format(expectedMessageLowerSec, "S1 NT"));
     }
 
     @Test


### PR DESCRIPTION
**Testing-Related**
1. Added more test cases for `NameTest` covering multiple spaces and different casing + multiple spaces.
1. Added more tests for  `LevelTest`, `SubjectTest`.
1. Added more tests for name (different casing and multiple spaces) for `AddCommandParserTest`, `UpdateTaskCommandParserTest` and `UpdateCommandParserTest`.

**Bug Fixes**
1. Error message for invalid subjects.
    - Used `parseSubjects` instead of `parseSubjectsByLevel` to validate that all subjects are valid ignoring level. This is to ensure that `Subject.MESSAGE_CONSTRAINTS` is returned.
    - Then validate the parsedSubjects and check whether each `Subject` is valid for the provided `Level`. This is to ensure that `Subject.getValidSubjectMessage()` is returned instead of `Subject.MESSAGE_CONSTRAINTS` if `parseSubjectsByLevel` was used. 
1. Level keyword should accept one argument (`AddCommandParser`).
  ![image](https://github.com/user-attachments/assets/9a1671f4-d2b8-42d5-b35c-d8519f2450d5)
1. Level keyword should accept one argument (`UpdateCommandParser`).

**DG**
1. Fixed an erroneous invalid test case in the appendix
1. Added some separators between sections

**Other Changes**
1. Created new method in `Subject` for testing purposes and updated the javadocs .
1. Removed `parseSubjectsByLevel` and `parseSubjectByLevel` in `ParserUtil` since it is no longer used.
1. Added a new validation check for `isValidLevelName` in `Level`, `S1 NONE` and `NONE IP` are considered invalid levels.

close #68, close #71, close #72, close #123, close #149, close #150, close #159