### PR TITLE
Move subject validation from AddCommandParser to AddCommand

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,12 +15,13 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
-    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_NAME = "The student name provided is invalid";
+    public static final String MESSAGE_STUDENT_NOT_FOUND =
+            "No student found with the specified name. Please check the name and try again";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_INVALID_STUDENT_UPDATE =
-                "This student does not exist. Create a student first before updating";
+            "This student does not exist. Create a student first before updating";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.Subject;
 import seedu.address.ui.Ui.UiState;
 
 /**
@@ -57,6 +58,11 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        // Validate that the subjects are compatible with the specified level
+        if (!Subject.isValidSubjectsByLevel(toAdd.getLevel(), toAdd.getSubjects())) {
+            throw new CommandException(Subject.getValidSubjectMessage());
+        }
 
         if (model.hasStudent(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -59,8 +59,8 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Validate that the subjects are compatible with the specified level
-        if (!Subject.isValidSubjectsByLevel(toAdd.getLevel(), toAdd.getSubjects())) {
+        // Validate that the subjects are compatible with the specified level if subjects are not empty
+        if (!toAdd.getSubjects().isEmpty() && !Subject.isValidSubjectsByLevel(toAdd.getLevel(), toAdd.getSubjects())) {
             throw new CommandException(Subject.getValidSubjectMessage());
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -68,7 +68,7 @@ public class DeleteTaskCommand extends Command {
                 .filter(x -> x.getName().equals(targetName))
                 .findFirst();
         if (optionalStudent.isEmpty()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+            throw new CommandException(Messages.MESSAGE_STUDENT_NOT_FOUND);
         }
         Student targetStudent = optionalStudent.get();
 

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -60,7 +60,7 @@ public class NoteCommand extends Command {
         }
 
         if (studentToEdit == null) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+            throw new CommandException(Messages.MESSAGE_STUDENT_NOT_FOUND);
         }
 
         Student editedStudent = new Student(

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -47,7 +47,7 @@ public class ViewCommand extends Command {
         }
 
         if (studentToView == null) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+            throw new CommandException(Messages.MESSAGE_STUDENT_NOT_FOUND);
         }
 
         return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, name),

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -70,11 +70,6 @@ public class AddCommandParser implements Parser<AddCommand> {
             }
 
             subjectList = ParserUtil.parseSubjects(argMultimap.getAllValues(PREFIX_SUBJECT));
-
-            if (!Subject.isValidSubjectsByLevel(level,
-                    subjectList)) {
-                throw new ParseException(Subject.getValidSubjectMessage());
-            }
         }
 
         Set<LessonTime> lessonTimes = ParserUtil.parseLessonTimes(argMultimap.getAllValues(PREFIX_LESSON_TIME));

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -62,13 +62,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (argMultimap.getValue(PREFIX_LEVEL).isPresent()) {
             level = ParserUtil.parseLevel(argMultimap.getValue(PREFIX_LEVEL).get());
         }
-
         Set<Subject> subjectList = new HashSet<>();
         if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
             if (argMultimap.getValue(PREFIX_LEVEL).isEmpty()) {
                 throw new ParseException(Subject.MESSAGE_LEVEL_NEEDED);
             }
-
             subjectList = ParserUtil.parseSubjects(argMultimap.getAllValues(PREFIX_SUBJECT));
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -54,6 +54,34 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_invalidSubjectStudent_throwsCommandException() {
+        // upper secondary
+        Student invalidStudent = new StudentBuilder().withLevel("S3 NA").withSubjects("Math").build();
+        AddCommand addCommand = new AddCommand(invalidStudent);
+        ModelStub modelStub = new ModelStubWithStudent(invalidStudent);
+
+        String expectedMessageUpperSec = "Subject is not valid for given level. "
+                + "Valid subjects for S3 NA: [A_MATH, E_MATH, PHYSICS, CHEMISTRY, "
+                + "BIOLOGY, COMBINED_SCIENCE, ACCOUNTING, LITERATURE, HISTORY, GEOGRAPHY, "
+                + "SOCIAL_STUDIES, MUSIC, ART, ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, "
+                + "HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
+
+        assertThrows(CommandException.class, expectedMessageUpperSec, () -> addCommand.execute(modelStub));
+
+        // lower secondary
+        invalidStudent = new StudentBuilder().withLevel("S1 IP").withSubjects("combined_science").build();
+        AddCommand otherAddCommand = new AddCommand(invalidStudent);
+        ModelStub otherModelStub = new ModelStubWithStudent(invalidStudent);
+
+        String expectedMessageLowerSec = "Subject is not valid for given level. Valid subjects for S1 IP: "
+                + "[MATH, SCIENCE, PHYSICS, CHEMISTRY, BIOLOGY, LITERATURE, HISTORY, GEOGRAPHY, SOCIAL_STUDIES, "
+                + "ENGLISH, CHINESE, HIGHER_CHINESE, MALAY, HIGHER_MALAY, TAMIL, HIGHER_TAMIL, HINDI]";
+
+        assertThrows(CommandException.class, expectedMessageLowerSec, () -> otherAddCommand.execute(otherModelStub));
+    }
+
+
+    @Test
     public void equals() {
         Student alice = new StudentBuilder().withName("Alice").build();
         Student bob = new StudentBuilder().withName("Bob").build();

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -87,7 +87,7 @@ public class DeleteTaskCommandTest {
     public void execute_invalidName_throwsCommandException() {
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(new Name("UNKNOWN NAME"), INDEX_FIRST_TASK);
 
-        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_STUDENT_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
@@ -59,7 +59,7 @@ public class NoteCommandTest {
     public void execute_invalidStudentName_failure() {
         Name invalidName = new Name("FancyPants");
         NoteCommand noteCommand = new NoteCommand(invalidName, new Note(VALID_NOTE_BOB));
-        assertCommandFailure(noteCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+        assertCommandFailure(noteCommand, model, Messages.MESSAGE_STUDENT_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -143,7 +143,6 @@ public class TagCommandTest {
 
     @Test
     public void execute_tagStudentWithNoSubjectsWithLevel_success() {
-
         //Remove subjects of student in address book
         Student studentInList = model.getAddressBook()
                 .getStudentList()
@@ -173,8 +172,6 @@ public class TagCommandTest {
 
     @Test
     public void execute_invalidLevelForStudentSubjects_failure() throws CommandException {
-
-
         Name studentInList = model.getAddressBook()
                 .getStudentList()
                 .get(INDEX_SECOND_STUDENT
@@ -242,5 +239,4 @@ public class TagCommandTest {
 
         assertEquals(expected, tagCommand.toString());
     }
-
 }

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -170,7 +170,6 @@ public class UpdateCommandTest {
 
     @Test
     public void execute_updateStudentWithNoSubjectsWithLevel_success() {
-
         //Remove subjects of student in address book
         Student studentInList = model.getAddressBook()
                 .getStudentList()

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -43,7 +43,7 @@ public class ViewCommandTest {
     public void execute_invalidStudentName_failure() {
         Name invalidName = new Name("FancyPants");
         ViewCommand viewCommand = new ViewCommand(invalidName);
-        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_NAME);
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_STUDENT_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -27,7 +27,6 @@ import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_TUE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_ENGLISH;
@@ -250,11 +249,6 @@ public class AddCommandParserTest {
         // adding student with incorrect level NONE IP
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
                 + ADDRESS_DESC_BOB + " l/NONE IP", Level.MESSAGE_CONSTRAINTS);
-
-        // adding student with level but with an incorrect subject
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
-                + ADDRESS_DESC_BOB + LEVEL_DESC_S4_NT + SUBJECT_DESC_MATH,
-                Subject.getValidSubjectMessage(new Level(VALID_LEVEL_S4_NT)));
 
         // adding student with invalid lesson time
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB


### PR DESCRIPTION
1. Small change to align with TagCommand and UpdateCommand, where the subject validation is handled in their Command class and not their Parser class.

1. Change message when no matching student is found to sound more appropriate.

close #168, close #144