### PR TITLE
Fix bugs for Find Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,7 +84,7 @@ EduManage is a **desktop app for managing contacts, optimized for use via a Comm
 |   1   |               [`Add`](#adding-a-student)               |         `add n/NAME p/PHONE_NUMBER e/EMERGENCY_CONTACT a/ADDRESS [l/LEVEL] [s/SUBJECT]…​ [lt/LESSON_TIME]…​`         | `add n/James Ho p/98765432 e/93838420 a/311, Clementi Ave 2, #02-25 l/S1 NT s/MATH lt/SUN-11:00-13:00` |
 |   2   |            [`Delete`](#deleting-a-student)             |                                                    `delete INDEX`                                                    |                                               `delete 2`                                               |
 |   3   |            [`Update`](#updating-a-student)             | `update NAME [n/NAME] [p/PHONE_NUMBER] [e/EMERGENCY_CONTACT] [a/ADDRESS] [l/LEVEL] [s/SUBJECT]…​ [lt/LESSON_TIME]…​` |                               `update Alex Yeoh n/James Lee e/99999999`                                |
-|   4   |              [`Find`](#finding-students)               |                         `find n/KEYWORDS` or `find l/LEVEL` or `find s/SUBJECT [SUBJECT]…​`                          |                         `find n/Alex David` or `find l/S2 NA` or `find s/MATH`                         |
+|   4   |              [`Find`](#finding-students)               |                       `find n/NAME [NAME]…​` or `find l/LEVEL` or `find s/SUBJECT [SUBJECT]…​`                       |                         `find n/Alex David` or `find l/S2 NA` or `find s/MATH`                         |
 |   5   |            [`List`](#listing-all-students)             |                                                        `list`                                                        |                                                 `list`                                                 |
 |   6   |              [`Tag`](#tagging-a-student)               |                                         `tag n/NAME [l/LEVEL] [s/SUBJECT]…​`                                         |                                    `tag n/John Doe l/S1 NT s/MATH`                                     |
 |   7   |           [`Record Note`](#recording-notes)            |                                                `note n/NAME nt/NOTE`                                                 |                            `note n/John Doe nt/Doing well in all subjects`                             |
@@ -207,20 +207,22 @@ Updates the details of an existing student in the address book.
 Find students by either their name, level or subject(s).
 
 **Format:**
-1. `find n/KEYWORDS`
+1. `find n/NAME [NAME]…​`
 1. `find l/LEVEL`
 1. `find s/SUBJECT [SUBJECT]…​`
 
-* The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Students matching at least one keyword will be returned (i.e. `OR` search).
+* The search is case-insensitive and treats multiple spaces as one space. e.g `hans` will match `Hans` and `s2   nt` will match `S2 NT`
+* For name and subject searches, the order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
+* For name and subject searches, students matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+  e.g. `MATH CHEMISTRY` will return students with `MATH` or `CHEMISTRY`
 
 **Examples:**
 * `find n/John` returns `john` and `John Doe`
 * `find l/S3 NA` returns all students tagged with level `S3 NA`
 * `find s/MATH` returns all students tagged with subject `MATH`
-* `find n/alex david` returns `Alex Yeoh`, `David Li`<br>
+* `find n/alex david` returns `Alex Yeoh`, `David Li`
+* `find s/Math chemistry` returns all students tagged with subjects `MATH` or `CHEMISTRY`<br>
 
   ![result for 'find n/alex david'](images/findAlexDavidResult.png)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -211,18 +211,18 @@ Find students by either their name, level or subject(s).
 1. `find l/LEVEL`
 1. `find s/SUBJECT [SUBJECT]…​`
 
-* The search is case-insensitive and treats multiple spaces as one space. e.g `hans` will match `Hans` and `s2   nt` will match `S2 NT`
-* For name and subject searches, the order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
+* The search is case-insensitive and treats multiple spaces as one space. e.g `hans` will match `Hans` and `s2   nt` will match `S2 NT`.
+* For name and subject searches, the order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
 * For name and subject searches, students matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
-  e.g. `MATH CHEMISTRY` will return students with `MATH` or `CHEMISTRY`
+  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`.
+  e.g. `MATH CHEMISTRY` will return students with `MATH` or `CHEMISTRY`.
 
 **Examples:**
-* `find n/John` returns `john` and `John Doe`
-* `find l/S3 NA` returns all students tagged with level `S3 NA`
-* `find s/MATH` returns all students tagged with subject `MATH`
-* `find n/alex david` returns `Alex Yeoh`, `David Li`
-* `find s/Math chemistry` returns all students tagged with subjects `MATH` or `CHEMISTRY`<br>
+* `find n/John` returns `john` and `John Doe`.
+* `find l/S3 NA` returns all students tagged with level `S3 NA`.
+* `find s/MATH` returns all students tagged with subject `MATH`.
+* `find n/alex david` returns `Alex Yeoh`, `David Li`.
+* `find s/Math chemistry` returns all students tagged with subjects `MATH` or `CHEMISTRY`.<br>
 
   ![result for 'find n/alex david'](images/findAlexDavidResult.png)
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -22,10 +22,12 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students based on either name, subject(s) or"
             + " level, using the specified keywords (case-insensitive) and "
             + "displays them as a list with index numbers.\n"
-            + "Parameters (choose only one): " + PREFIX_NAME + "KEYWORDS or "
+            + "Parameters (choose only one): " + PREFIX_NAME + "NAME [NAME]... or "
             + PREFIX_LEVEL + "LEVEL or "
             + PREFIX_SUBJECT + "SUBJECT [SUBJECT]..." + "\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Alex David";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Alex David or "
+            + COMMAND_WORD + " " + PREFIX_LEVEL + "S2 NA or "
+            + COMMAND_WORD + " " + PREFIX_SUBJECT + "MATH";
 
     private final ContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,14 +1,12 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
 import java.util.Arrays;
-import java.util.List;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,15 +1,19 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.Level;
+import seedu.address.model.student.Name;
 import seedu.address.model.student.Subject;
 import seedu.address.model.student.predicate.LevelContainsKeywordsPredicate;
 import seedu.address.model.student.predicate.NameContainsKeywordsPredicate;
@@ -43,23 +47,44 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (isByName) {
             String toFind = argMultimap.getValue(PREFIX_NAME).get();
-            String[] nameKeywords = toFind.split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+
+            // Code below conducts checks usually done in parse,
+            // but ParserUtil is not used as Name objects are not needed.
+            requireNonNull(toFind);
+            String[] trimmedNames = toFind.trim().split("\\s+");
+            if (Arrays.stream(trimmedNames).anyMatch(name -> !Name.isValidName(name))) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            }
+
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(trimmedNames)));
         } else if (isByLevel) {
             String toFind = argMultimap.getValue(PREFIX_LEVEL).get();
-            String[] levelKeywords = {toFind};
 
-            if (Arrays.stream(levelKeywords).anyMatch(level -> !Level.isValidLevelName(level))) {
+            // Code below conducts checks usually done in parse,
+            // but ParserUtil is not used as Level object is not needed.
+            requireNonNull(toFind);
+            String trimmedLevel = toFind.trim();
+            if (!Level.isValidLevelName(trimmedLevel)) {
                 throw new ParseException(Level.MESSAGE_CONSTRAINTS);
             }
-            return new FindCommand(new LevelContainsKeywordsPredicate(Arrays.asList(levelKeywords)));
+
+            // Remove spaces within and make all upper case
+            trimmedLevel = String.join(" ", trimmedLevel.split("\\s+")).toUpperCase();
+
+            String[] trimmedLevels = {trimmedLevel};
+            return new FindCommand(new LevelContainsKeywordsPredicate(Arrays.asList(trimmedLevels)));
         } else {
             String toFind = argMultimap.getValue(PREFIX_SUBJECT).get();
-            String[] subjectKeywords = toFind.split("\\s+");
-            if (Arrays.stream(subjectKeywords).anyMatch(subject -> !Subject.isValidSubjectName(subject))) {
+
+            // Code below conducts checks usually done in parse,
+            // but ParserUtil is not used as Subject objects are not needed.
+            requireNonNull(toFind);
+            String[] trimmedSubjects = toFind.trim().split("\\s+");
+            if (Arrays.stream(trimmedSubjects).anyMatch(subject -> !Subject.isValidSubjectName(subject))) {
                 throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
             }
-            return new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList(subjectKeywords)));
+
+            return new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList(trimmedSubjects)));
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -79,9 +79,16 @@ public class FindCommandParserTest {
                 new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList("MATH")));
         assertParseSuccess(parser, " s/MATH", expectedFindCommand);
 
+        FindCommand expectedFindCommandLower =
+                new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList("math")));
+        assertParseSuccess(parser, " s/math", expectedFindCommandLower);
+
         FindCommand expectedFindCommandMany =
                 new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList("MATH", "CHEMISTRY")));
         assertParseSuccess(parser, " s/MATH CHEMISTRY", expectedFindCommandMany);
+        assertParseSuccess(parser, " s/MATH     CHEMISTRY", expectedFindCommandMany);
+        assertParseSuccess(parser, " s/    MATH CHEMISTRY", expectedFindCommandMany);
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.Level;
+import seedu.address.model.student.Name;
 import seedu.address.model.student.Subject;
 import seedu.address.model.student.predicate.LevelContainsKeywordsPredicate;
 import seedu.address.model.student.predicate.NameContainsKeywordsPredicate;
@@ -49,15 +50,27 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_invalidNameArgs_throwsParseException() {
+        assertParseFailure(parser, " n/", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " n/&^$*(^", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " n/    ", Name.MESSAGE_CONSTRAINTS);
+
+    }
+
+    @Test
     public void parse_validLevelArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =
                 new FindCommand(new LevelContainsKeywordsPredicate(Arrays.asList("S1 NA")));
         assertParseSuccess(parser, " l/S1 NA", expectedFindCommand);
+        assertParseSuccess(parser, " l/s1 na", expectedFindCommand);
+        assertParseSuccess(parser, " l/s1      na", expectedFindCommand);
     }
 
     @Test
     public void parse_invalidLevelArgs_throwsParseException() {
         assertParseFailure(parser, " l/Sec1", Level.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " l/", Level.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " l/   ", Level.MESSAGE_CONSTRAINTS);
     }
 
     @Test
@@ -65,11 +78,17 @@ public class FindCommandParserTest {
         FindCommand expectedFindCommand =
                 new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList("MATH")));
         assertParseSuccess(parser, " s/MATH", expectedFindCommand);
+
+        FindCommand expectedFindCommandMany =
+                new FindCommand(new SubjectContainsKeywordsPredicate(Arrays.asList("MATH", "CHEMISTRY")));
+        assertParseSuccess(parser, " s/MATH CHEMISTRY", expectedFindCommandMany);
     }
 
     @Test
     public void parse_invalidSubjectArgs_throwsParseException() {
         assertParseFailure(parser, " s/MATHEMATIC", Subject.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " s/    ", Subject.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " s/", Subject.MESSAGE_CONSTRAINTS);
     }
 
 }


### PR DESCRIPTION
Updated checks for Name in FindCommandParser so that empty and invalid names are rejected. (closes #118, closes #138)

Reformatted input for Level in FindCommandParser so that Level search is case and space insensitive. (closes #140, closes #141)

Update format of Subject and Name field in UG and command usage message for clarity. (closes #167)