### PR TITLE
Ensure CommandParser uses student field parsers.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.parseNote;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -54,7 +55,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 .parseEmergencyContact(argMultimap.getValue(PREFIX_EMERGENCY_CONTACT)
                 .get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Note note = new Note("");
+        Note note = parseNote("");
         TaskList taskList = new TaskList();
 
         //Parse optional arguments

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.ParserUtil.parseNote;
 
 import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -33,6 +34,6 @@ public class NoteCommandParser implements Parser<NoteCommand> {
 
         Name studentName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
 
-        return new NoteCommand(studentName, new Note(note));
+        return new NoteCommand(studentName, parseNote(note));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.ParserUtil.parseNote;
 import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.Name;
-import seedu.address.model.student.Note;
 
 /**
  * Parses input arguments and creates a new {@code NoteCommand} object

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,16 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_NA;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S1_NA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_DEADLINE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_DESCRIPTION_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_DESCRIPTION_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.ParserUtil.parseLevel;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
@@ -35,6 +38,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NoteCommand;
+import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
 import seedu.address.logic.commands.UpdateTaskCommand;
@@ -61,6 +65,15 @@ public class AddressBookParserTest {
         Student student = new StudentBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(StudentUtil.getAddCommand(student));
         assertEquals(new AddCommand(student), command);
+    }
+
+    @Test
+    public void parseCommand_tag() throws Exception {
+        String userInput = TagCommand.COMMAND_WORD + NAME_DESC_AMY + LEVEL_DESC_S1_NA;
+        TagCommand command =(TagCommand) parser.parseCommand(userInput);
+        UpdateStudentDescriptor editStudentTags = new UpdateStudentDescriptor();
+        editStudentTags.setLevel(parseLevel(VALID_LEVEL_S1_NA));
+        assertEquals(new TagCommand(new Name(VALID_NAME_AMY), editStudentTags), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -70,7 +70,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_tag() throws Exception {
         String userInput = TagCommand.COMMAND_WORD + NAME_DESC_AMY + LEVEL_DESC_S1_NA;
-        TagCommand command =(TagCommand) parser.parseCommand(userInput);
+        TagCommand command = (TagCommand) parser.parseCommand(userInput);
         UpdateStudentDescriptor editStudentTags = new UpdateStudentDescriptor();
         editStudentTags.setLevel(parseLevel(VALID_LEVEL_S1_NA));
         assertEquals(new TagCommand(new Name(VALID_NAME_AMY), editStudentTags), command);


### PR DESCRIPTION
Had instances where command parser did not use parse method and caused bugs.

Let's:
*Ensure student field object is created through its corresponding parsers