### PR TITLE
Update UI Display

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -49,6 +49,7 @@ ResultDisplay --|> UiPart
 CommandBox --|> UiPart
 StudentListPanel --|> UiPart
 StudentCard --|> UiPart
+StudentTaskCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 DetailsDisplay --|> UiPart

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -69,6 +70,7 @@ public class AddCommand extends Command {
         }
 
         model.addStudent(toAdd);
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)), UiState.DETAILS);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.student.Note;
 import seedu.address.model.student.Phone;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.Subject;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.model.student.task.TaskList;
 import seedu.address.ui.Ui.UiState;
@@ -74,9 +75,11 @@ public class AddTaskCommand extends Command {
         Student updatedStudent = createUpdatedStudent(targetStudent, taskToAdd);
 
         model.setStudent(targetStudent, updatedStudent);
+        model.updateFilteredStudentList(new TaskListNotEmptyPredicate());
+
         return new CommandResult(String.format(MESSAGE_SUCCESS,
                 taskToAdd.getTaskDescription(), targetStudent.getName(), taskToAdd.getTaskDeadline()),
-                UiState.DETAILS);
+                UiState.TASKS);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -45,7 +45,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this(feedbackToUser, showHelp, exit, UiState.DETAILS, null);
+        this(feedbackToUser, showHelp, exit, UiState.NO_CHANGE, null);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 
@@ -43,8 +44,10 @@ public class DeleteCommand extends Command {
 
         Student studentToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteStudent(studentToDelete);
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+
         return new CommandResult(String.format(MESSAGE_DELETE_STUDENT_SUCCESS, Messages.format(studentToDelete)),
-                UiState.NO_CHANGE);
+                UiState.DETAILS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -44,7 +44,7 @@ public class DeleteCommand extends Command {
         Student studentToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteStudent(studentToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_STUDENT_SUCCESS, Messages.format(studentToDelete)),
-                UiState.DETAILS);
+                UiState.NO_CHANGE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -22,6 +22,7 @@ import seedu.address.model.student.Note;
 import seedu.address.model.student.Phone;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.Subject;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.model.student.task.TaskList;
 import seedu.address.ui.Ui.UiState;
@@ -82,11 +83,13 @@ public class DeleteTaskCommand extends Command {
         //Creates a new Student with the task removed
         Student updatedStudent = createUpdatedStudent(targetStudent, taskToDelete);
         model.setStudent(targetStudent, updatedStudent);
+        model.updateFilteredStudentList(new TaskListNotEmptyPredicate());
+
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS,
                 taskToDelete.getTaskDescription(),
                 targetStudent.getName(),
                 taskToDelete.getTaskDeadline()),
-                UiState.DETAILS);
+                UiState.TASKS);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.model.student.task.TaskDeadline;
 import seedu.address.model.student.task.TaskDescription;
@@ -96,9 +97,10 @@ public class UpdateTaskCommand extends Command {
                 .orElse(originalTask.getTaskDescription());
         TaskDeadline updatedTaskDeadline = updateTaskDescriptor.getTaskDeadline()
                 .orElse(originalTask.getTaskDeadline());
+        model.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
         return new CommandResult(String.format(MESSAGE_UPDATE_TASK_SUCCESS, updatedTaskDescription,
-                updatedStudent.getName(), updatedTaskDeadline), UiState.DETAILS);
+                updatedStudent.getName(), updatedTaskDeadline), UiState.TASKS);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.List;
 
@@ -49,6 +50,8 @@ public class ViewCommand extends Command {
         if (studentToView == null) {
             throw new CommandException(Messages.MESSAGE_STUDENT_NOT_FOUND);
         }
+
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
 
         return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, name),
                 studentToView);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -149,6 +149,8 @@ public class ModelManager implements Model {
         }
 
         ModelManager otherModelManager = (ModelManager) other;
+        System.out.println(filteredStudents);
+        System.out.println(otherModelManager.filteredStudents + "\n\n");
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredStudents.equals(otherModelManager.filteredStudents);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -149,8 +149,6 @@ public class ModelManager implements Model {
         }
 
         ModelManager otherModelManager = (ModelManager) other;
-        System.out.println(filteredStudents);
-        System.out.println(otherModelManager.filteredStudents + "\n\n");
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredStudents.equals(otherModelManager.filteredStudents);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -178,6 +178,9 @@ public class MainWindow extends UiPart<Stage> {
      */
     private void handleUiState(CommandResult commandResult) {
         UiState uiState = commandResult.getUiState();
+        if (uiState == UiState.NO_CHANGE) {
+            return;
+        }
         if (uiState == UiState.SPECIFIC_DETAILS) {
             mainSplitPane.setDividerPosition(0, 0.5);
             DetailsDisplay detailsDisplay = new DetailsDisplay(commandResult.getStudentToView());

--- a/src/main/java/seedu/address/ui/StudentListPanel.java
+++ b/src/main/java/seedu/address/ui/StudentListPanel.java
@@ -36,7 +36,9 @@ public class StudentListPanel extends UiPart<Region> {
      * Updates UI state of list panel.
      */
     public void updateUiState(UiState uiState) {
-        this.uiState = uiState;
+        if (uiState != UiState.NO_CHANGE) {
+            this.uiState = uiState;
+        }
 
         // Reset the items to force ListView to update
         ObservableList<Student> currentItems = studentListView.getItems();

--- a/src/main/java/seedu/address/ui/Ui.java
+++ b/src/main/java/seedu/address/ui/Ui.java
@@ -11,7 +11,7 @@ public interface Ui {
      * States of UI display.
      */
     public enum UiState {
-        DETAILS, TASKS, SPECIFIC_DETAILS
+        DETAILS, TASKS, SPECIFIC_DETAILS, NO_CHANGE
     }
 
     /** Starts the UI (and the App).  */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -188,7 +188,7 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredStudentList(Predicate<Student> predicate) {
-            throw new AssertionError("This method should not be called.");
+            return;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -17,6 +17,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.TaskBuilder;
@@ -54,12 +55,13 @@ public class AddTaskCommandTest {
         Student updatedStudent = new StudentBuilder(student).build(); // Create a deep copy
         updatedStudent.getTaskList().add(validTask); // Modify the deep copy
         expectedModel.setStudent(student, updatedStudent);
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
         // Checks that initial and expected state of model is correct
         assertEquals(model, new ModelManager(getTypicalAddressBook(), new UserPrefs()));
         assertNotEquals(expectedModel, model);
 
-        assertCommandSuccess(addTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(addTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,10 +14,10 @@ import seedu.address.ui.Ui.UiState;
 public class CommandResultTest {
     @Test
     public void equals() {
-        CommandResult commandResult1 = new CommandResult("feedback", UiState.DETAILS);
+        CommandResult commandResult1 = new CommandResult("feedback", UiState.NO_CHANGE);
 
         // same values -> returns true
-        assertTrue(commandResult1.equals(new CommandResult("feedback", UiState.DETAILS)));
+        assertTrue(commandResult1.equals(new CommandResult("feedback", UiState.NO_CHANGE)));
         assertTrue(commandResult1.equals(new CommandResult("feedback", false, false)));
 
         // same object -> returns true
@@ -30,7 +30,7 @@ public class CommandResultTest {
         assertFalse(commandResult1.equals(0.5f));
 
         // different feedbackToUser value -> returns false
-        assertFalse(commandResult1.equals(new CommandResult("different", UiState.DETAILS)));
+        assertFalse(commandResult1.equals(new CommandResult("different", UiState.NO_CHANGE)));
 
         // different showHelp value -> returns false
         assertFalse(commandResult1.equals(new CommandResult("feedback", true, false)));

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
@@ -37,8 +38,9 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteStudent(studentToDelete);
+        expectedModel.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.NO_CHANGE, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
     }
 
     @Test
@@ -62,8 +64,9 @@ public class DeleteCommandTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteStudent(studentToDelete);
         showNoStudent(expectedModel);
+        expectedModel.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.NO_CHANGE, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -38,7 +38,7 @@ public class DeleteCommandTest {
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteStudent(studentToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.NO_CHANGE, expectedModel);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class DeleteCommandTest {
         expectedModel.deleteStudent(studentToDelete);
         showNoStudent(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, UiState.NO_CHANGE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -20,6 +20,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.model.student.task.TaskDeadline;
 import seedu.address.model.student.task.TaskDescription;
@@ -69,9 +70,10 @@ public class DeleteTaskCommandTest {
         updatedTaskList.remove(targetTask);
         expectedModel.setStudent(targetStudent, updatedStudent);
         assertEquals(expectedModel, new ModelManager(getTypicalAddressBook(), new UserPrefs()));
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
         assertNotEquals(model, expectedModel);
 
-        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UpdateTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateTaskCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicate.TaskListNotEmptyPredicate;
 import seedu.address.model.student.task.Task;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.TaskBuilder;
@@ -65,8 +66,9 @@ public class UpdateTaskCommandTest {
         } else {
             throw new IllegalStateException("Student to update not found");
         }
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
-        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test
@@ -90,8 +92,9 @@ public class UpdateTaskCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(targetStudent, updatedStudent);
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
-        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test
@@ -115,8 +118,9 @@ public class UpdateTaskCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(targetStudent, updatedStudent);
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
-        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test
@@ -131,8 +135,9 @@ public class UpdateTaskCommandTest {
                         updatedTask.getTaskDescription(), updatedStudent.getName(), updatedTask.getTaskDeadline());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
-        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test
@@ -157,8 +162,9 @@ public class UpdateTaskCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), updatedStudent);
+        expectedModel.updateFilteredStudentList(new TaskListNotEmptyPredicate());
 
-        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+        assertCommandSuccess(updateTaskCommand, model, expectedMessage, UiState.TASKS, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Some of the current commands do not update the UI properly, like help changing the UI state and task commands changing the state to show student details.

The way the UI state changes is not intuitive, and affects user experience.

Let's change how the UI state gets updated, having student commands display student details, having task commands display task details and having miscellaneous commands not change the UI state.

This makes the UI state align with the types of commands used, enhancing user experience.

Additionally edited the UML Class Diagram for UI to make StudentTaskCard inherit from UiPart.

This is how the UI state will change for each command:

- add, update, find, list, tag, record note, view specific student (always change to student details)
- add task, delete task, update task, view all tasks (always change to task details)   
- clear, delete, help, exit (unchanged)

Closes #133, closes #143, closes #158. closes #161 