### PR TITLE
Show error when tagging students without level

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -106,6 +106,10 @@ public class TagCommand extends Command {
         Set<Subject> updatedSubjects = newSubjects.orElse(studentToTag.getSubjects());
 
         if (updatedLevel.equals(new Level("None None"))) {
+            if (newSubjects.isPresent()) {
+                throw new CommandException(Subject.MESSAGE_LEVEL_NEEDED);
+            }
+
             updatedSubjects = new HashSet<Subject>();
         }
 

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -119,6 +119,10 @@ public class UpdateCommand extends Command {
         Set<Subject> updatedSubjects = newSubjects.orElse(studentToUpdate.getSubjects());
 
         if (updatedLevel.equals(new Level("None None"))) {
+            if (newSubjects.isPresent()) {
+                throw new CommandException(Subject.MESSAGE_LEVEL_NEEDED);
+            }
+
             updatedSubjects = new HashSet<Subject>();
         }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,9 +75,4 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
-
-    @Override
-    public String toString() {
-        return argMultimap.toString();
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,9 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    @Override
+    public String toString() {
+        return argMultimap.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.Name;
+import seedu.address.model.student.Subject;
 
 /**
  * Parses input arguments and creates a new TagCommand object
@@ -27,6 +28,7 @@ public class TagCommandParser implements Parser<TagCommand> {
         ArgumentMultimap argMultiMap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_SUBJECT, PREFIX_LEVEL);
         argMultiMap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_LEVEL);
+
 
         if (!arePrefixesPresent(argMultiMap, PREFIX_NAME) || !argMultiMap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
@@ -49,13 +51,21 @@ public class TagCommandParser implements Parser<TagCommand> {
         }
 
         if (argMultiMap.getValue(PREFIX_SUBJECT).isPresent()) {
-            editStudentTags.setSubjects(
-                    ParserUtil.parseSubjects(
-                            argMultiMap.getAllValues(PREFIX_SUBJECT)));
+            try {
+                editStudentTags.setSubjects(
+                        ParserUtil.parseSubjects(
+                                argMultiMap.getAllValues(PREFIX_SUBJECT)));
+            } catch (ParseException e) {
+                if (editStudentTags.getLevel().isPresent()) {
+                    throw new ParseException(Subject.getValidSubjectMessage(editStudentTags.getLevel().get()));
+                }
+                throw new ParseException(e.getMessage());
+            }
         }
 
         if (argMultiMap.getValue(PREFIX_SUBJECT).isEmpty()) {
             if (argMultiMap.getValue(PREFIX_LEVEL).isEmpty()) {
+
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
             }
         }

--- a/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
@@ -75,9 +75,21 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
         if (argMultimap.getValue(PREFIX_LEVEL).isPresent()) {
             updateStudentDescriptor.setLevel(ParserUtil.parseLevel(argMultimap.getValue(PREFIX_LEVEL).get()));
         }
+        if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
+            try {
+                updateStudentDescriptor.setSubjects(
+                        ParserUtil.parseSubjects(
+                                argMultimap.getAllValues(PREFIX_SUBJECT)));
+            } catch (ParseException e) {
+                if (updateStudentDescriptor.getLevel().isPresent()) {
+                    throw new ParseException(Subject.getValidSubjectMessage(updateStudentDescriptor.getLevel().get()));
+                }
 
-        parseSubjectsForUpdate(argMultimap.getAllValues(PREFIX_SUBJECT))
-                .ifPresent(updateStudentDescriptor::setSubjects);
+                parseSubjectsForUpdate(argMultimap.getAllValues(PREFIX_SUBJECT))
+                        .ifPresent(updateStudentDescriptor::setSubjects);
+            }
+        }
+
         parseLessonTimesForUpdate(argMultimap.getAllValues(PREFIX_LESSON_TIME))
                 .ifPresent(updateStudentDescriptor::setLessonTimes);
         if (!updateStudentDescriptor.isAnyFieldUpdated()) {

--- a/src/main/java/seedu/address/model/student/Level.java
+++ b/src/main/java/seedu/address/model/student/Level.java
@@ -28,9 +28,9 @@ public class Level {
     }
 
     public static final String MESSAGE_CONSTRAINTS = "Level should be in the format YEAR TRACK, "
-            + "where Year is one of: [S1, S2, S3, S4, S5]"
-            + " and Track is one of: [EXPRESS, NA, NT, IP]"
-            + " with the exception of S5 which is only allowed to have the Track NA";
+            + "where Year is one of: [S1, S2, S3, S4]"
+            + " and Track is one of: [EXPRESS, NA, NT, IP].\n"
+            + "S5 is only allowed to have the Track NA";
 
     public final String levelName;
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="EduManage" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -24,12 +24,14 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.Subject;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.UpdateStudentDescriptorBuilder;
 import seedu.address.ui.Ui.UiState;
@@ -139,6 +141,26 @@ public class TagCommandTest {
     }
 
     @Test
+    public void execute_levelNoneNoneAndUpdatingSubjectOnly_failure() throws CommandException {
+        Index indexLastStudent = Index.fromOneBased(model.getFilteredStudentList().size());
+        Student lastStudent = model.getFilteredStudentList().get(indexLastStudent.getZeroBased());
+        System.out.println(lastStudent);
+
+        UpdateStudentDescriptor descriptor =
+                new UpdateStudentDescriptorBuilder().withLevel("NONE NONE").build();
+        new TagCommand(lastStudent.getName(), descriptor).execute(model);
+
+        Student lastStudentNoLevel = model.getFilteredStudentList().get(indexLastStudent.getZeroBased());
+
+        UpdateStudentDescriptor des =
+                new UpdateStudentDescriptorBuilder().withSubjects("Math").build();
+
+        TagCommand tagCommand = new TagCommand(lastStudentNoLevel.getName(), des);
+
+        assertCommandFailure(tagCommand, model, Subject.MESSAGE_LEVEL_NEEDED);
+    }
+
+    @Test
     public void execute_tagStudentWithNoSubjectsWithLevel_success() {
         //Remove subjects of student in address book
         Student studentInList = model.getAddressBook()
@@ -231,7 +253,6 @@ public class TagCommandTest {
         UpdateStudentDescriptor descriptor =
                 new UpdateStudentDescriptorBuilder()
                         .withLevel("NONE NONE")
-                        .withSubjects("MATH")
                         .build();
         TagCommand tagCommand = new TagCommand(studentInList.getName(), descriptor);
         Student finalStudent = new StudentBuilder(studentInList).withLevel("NONE NONE").withSubjects().build();

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -24,12 +24,14 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.Subject;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.UpdateStudentDescriptorBuilder;
 import seedu.address.ui.Ui.UiState;
@@ -155,7 +157,7 @@ public class UpdateCommandTest {
         Student updatedStudent = studentInList.withLevel("NONE NONE").withSubjects().build();
 
         UpdateStudentDescriptor descriptor =
-                new UpdateStudentDescriptorBuilder().withLevel("NONE NONE").withSubjects("A_MATH", "PHYSICS").build();
+                new UpdateStudentDescriptorBuilder().withLevel("NONE NONE").build();
         UpdateCommand updateCommand = new UpdateCommand(lastStudent.getName(), descriptor);
 
         String expectedMessage =
@@ -165,6 +167,26 @@ public class UpdateCommandTest {
         expectedModel.setStudent(lastStudent, updatedStudent);
 
         assertCommandSuccess(updateCommand, model, expectedMessage, UiState.DETAILS, expectedModel);
+    }
+
+    @Test
+    public void execute_levelNoneNoneAndUpdatingSubjectOnly_failure() throws CommandException {
+        Index indexLastStudent = Index.fromOneBased(model.getFilteredStudentList().size());
+        Student lastStudent = model.getFilteredStudentList().get(indexLastStudent.getZeroBased());
+        System.out.println(lastStudent);
+
+        UpdateStudentDescriptor descriptor =
+                new UpdateStudentDescriptorBuilder().withLevel("NONE NONE").build();
+        new UpdateCommand(lastStudent.getName(), descriptor).execute(model);
+
+        Student lastStudentNoLevel = model.getFilteredStudentList().get(indexLastStudent.getZeroBased());
+
+        UpdateStudentDescriptor des =
+                new UpdateStudentDescriptorBuilder().withSubjects("Math").build();
+
+        UpdateCommand updateCommand = new UpdateCommand(lastStudentNoLevel.getName(), des);
+
+        assertCommandFailure(updateCommand, model, Subject.MESSAGE_LEVEL_NEEDED);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -108,9 +108,13 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_update() throws Exception {
         Student student = new StudentBuilder().build();
-        UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder(student).build();
+
+        UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder(student)
+                .withSubjects("Math")
+                .build();
         UpdateCommand command = (UpdateCommand) parser.parseCommand(UpdateCommand.COMMAND_WORD + " "
                 + student.getName() + " " + StudentUtil.getUpdateStudentDescriptorDetails(descriptor));
+
         assertEquals(new UpdateCommand(student.getName(), descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -117,4 +117,18 @@ public class TagCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_LEVEL_DESC, Level.MESSAGE_CONSTRAINTS);
     }
 
+    @Test
+    public void parse_validLevelInvalidSubject_failure() {
+        String command = " n/John Doe l/S2 NA s/Chem";
+
+        assertParseFailure(parser, command, Subject.getValidSubjectMessage(new Level("S2 NA")));
+    }
+
+    @Test
+    public void parse_invalidLevelInvalidSubject_failure() {
+        String command = " n/John Doe s/Chem";
+
+        assertParseFailure(parser, command, Subject.MESSAGE_CONSTRAINTS);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -241,7 +241,6 @@ public class UpdateCommandParserTest {
 
         UpdateStudentDescriptor descriptor = new UpdateStudentDescriptorBuilder().withSubjects().build();
         UpdateCommand expectedCommand = new UpdateCommand(targetName, descriptor);
-
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -254,5 +253,18 @@ public class UpdateCommandParserTest {
         UpdateCommand expectedCommand = new UpdateCommand(targetName, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+    @Test
+    public void parse_validLevelInvalidSubject_failure() {
+        String command = " John Doe l/S2 NA s/Chem";
+
+        assertParseFailure(parser, command, Subject.getValidSubjectMessage(new Level("S2 NA")));
+    }
+
+    @Test
+    public void parse_invalidLevelInvalidSubject_failure() {
+        String command = " John Doe s/Chem";
+
+        assertParseFailure(parser, command, Subject.MESSAGE_CONSTRAINTS);
     }
 }


### PR DESCRIPTION
Updated behaviour:
- Tagging/Updating a student with `l/None None` clears the level and subjects
- Tagging/Updating a student with `l/None None` **and** a Subject either in the same command or a command after displays this error: `Tag a student with a level first or in the same command`

close #224
close #226
close #202  

- Tagging/Updating a student with a valid Level and an Invalid Subject shows error message detailing subjects allowed for a given level

close #203 

- Change name of app to EduManage

close #200 