### PR TITLE
Delete command: Change error handling in delete command

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,22 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if {@code s} represents an integer
+     * e.g. -1, 0, 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            return !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -17,13 +18,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        if (!StringUtil.isInteger(args.trim())) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+
+        Index index = ParserUtil.parseIndex(args);
+        return new DeleteCommand(index);
     }
 
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -45,6 +45,38 @@ public class StringUtilTest {
         assertTrue(StringUtil.isNonZeroUnsignedInteger("10"));
     }
 
+    //---------------- Tests for isInteger --------------------------------------
+
+    @Test
+    public void isInteger() {
+
+        // EP: empty strings
+        assertFalse(StringUtil.isInteger("")); // Boundary value
+        assertFalse(StringUtil.isInteger("  "));
+
+        // EP: not a number
+        assertFalse(StringUtil.isInteger("a"));
+        assertFalse(StringUtil.isInteger("aaa"));
+
+        // EP: zero
+        assertTrue(StringUtil.isInteger("0"));
+
+        // EP: zero as prefix
+        assertTrue(StringUtil.isInteger("01"));
+
+        // EP: numbers with + in front
+        assertFalse(StringUtil.isInteger("+1"));
+
+        // EP: numbers with white space
+        assertFalse(StringUtil.isInteger(" 10 ")); // Leading/trailing spaces
+        assertFalse(StringUtil.isInteger("1 0")); // Spaces in the middle
+
+        // EP: valid numbers, should return true
+        assertTrue(StringUtil.isInteger("1")); // Boundary value
+        assertTrue(StringUtil.isInteger("10"));
+        assertTrue(StringUtil.isInteger("-1"));
+    }
+
 
     //---------------- Tests for containsWordIgnoreCase --------------------------------------
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -28,5 +28,8 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 s/gfdg",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 }


### PR DESCRIPTION
Incorrect command format error is shown when input is 0, when the error should be that a positive number is needed.

Let's update the error handling to account for different types of errors.

closes #213 