### PR TITLE
TaskDeadline: Improve the error messages and not allow past dates to be added

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -201,8 +201,10 @@ public class ParserUtil {
     public static TaskDeadline parseTaskDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);
         String trimmedTDeadline = deadline.trim();
-        if (!TaskDeadline.isValidTaskDeadline(trimmedTDeadline)) {
+        if (!TaskDeadline.isValidDate(trimmedTDeadline)) {
             throw new ParseException(TaskDeadline.MESSAGE_CONSTRAINTS);
+        } else if (!TaskDeadline.isValidTaskDeadline(trimmedTDeadline)) {
+            throw new ParseException(TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE);
         }
         return new TaskDeadline(trimmedTDeadline);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -201,8 +201,10 @@ public class ParserUtil {
     public static TaskDeadline parseTaskDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);
         String trimmedTDeadline = deadline.trim();
-        if (!TaskDeadline.isValidDate(trimmedTDeadline)) {
+        if (!TaskDeadline.isValidFormat(trimmedTDeadline)) {
             throw new ParseException(TaskDeadline.MESSAGE_CONSTRAINTS);
+        } else if (!TaskDeadline.isValidDate(trimmedTDeadline)) {
+            throw new ParseException(TaskDeadline.MESSAGE_CONSTRAINTS_NONEXISTENT_DATE);
         } else if (!TaskDeadline.isValidTaskDeadline(trimmedTDeadline)) {
             throw new ParseException(TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE);
         }

--- a/src/main/java/seedu/address/model/student/task/TaskDeadline.java
+++ b/src/main/java/seedu/address/model/student/task/TaskDeadline.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeParseException;
  */
 public class TaskDeadline {
     public static final String MESSAGE_CONSTRAINTS = "Task deadline should be in the format YYYY-MM-DD";
+    public static final String MESSAGE_CONSTRAINTS_NONEXISTENT_DATE = "Date does not exist";
     public static final String MESSAGE_CONSTRAINTS_PAST_DATE = "Deadlines cannot be in the past."
             + " Please choose today's date or a future date.";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -40,6 +41,27 @@ public class TaskDeadline {
 
         TaskDeadline otherTaskDeadline = (TaskDeadline) other;
         return taskDeadline.equals(otherTaskDeadline.taskDeadline);
+    }
+
+    /**
+     * Returns true if a given string is a date.
+     */
+    public static boolean isValidFormat(String test) {
+        String[] dateArray = test.split("-");
+
+        if (dateArray.length != 3) {
+            return false;
+        }
+
+        boolean validYearFormat = dateArray[0].matches("\\d{4}");
+        boolean validMonthFormat = dateArray[1].matches("\\d{2}");
+        boolean validDayFormat = dateArray[2].matches("\\d{2}");
+
+        if (validYearFormat && validMonthFormat && validDayFormat) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/task/TaskDeadline.java
+++ b/src/main/java/seedu/address/model/student/task/TaskDeadline.java
@@ -9,10 +9,12 @@ import java.time.format.DateTimeParseException;
 
 /**
  * Represents a Task's taskDeadline in the address book.
- * Guarantees: immutable; is valid as declared in {@link #isValidTaskDeadline(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
  */
 public class TaskDeadline {
     public static final String MESSAGE_CONSTRAINTS = "Task deadline should be in the format YYYY-MM-DD";
+    public static final String MESSAGE_CONSTRAINTS_PAST_DATE = "Deadlines cannot be in the past."
+            + " Please choose today's date or a future date.";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public final LocalDate taskDeadline;
 
@@ -22,7 +24,7 @@ public class TaskDeadline {
      */
     public TaskDeadline(String taskDeadline) {
         requireNonNull(taskDeadline);
-        checkArgument(isValidTaskDeadline(taskDeadline), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidDate(taskDeadline), MESSAGE_CONSTRAINTS);
         this.taskDeadline = LocalDate.parse(taskDeadline, formatter);
     }
 
@@ -41,9 +43,9 @@ public class TaskDeadline {
     }
 
     /**
-     * Returns true if a given string is a valid task deadline.
+     * Returns true if a given string is a valid date.
      */
-    public static boolean isValidTaskDeadline(String test) {
+    public static boolean isValidDate(String test) {
         boolean isValidDeadline;
         try {
             LocalDate parsedDate = LocalDate.parse(test, formatter);
@@ -57,6 +59,18 @@ public class TaskDeadline {
             isValidDeadline = false;
         }
         return isValidDeadline;
+    }
+
+    /**
+     * Returns true if a given string is a valid date and is from today and onwards
+     */
+    public static boolean isValidTaskDeadline(String test) {
+        if (!isValidDate(test)) {
+            return false;
+        } else {
+            LocalDate parsedDate = LocalDate.parse(test, formatter);
+            return !parsedDate.isBefore(LocalDate.now());
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -52,7 +52,7 @@ public class JsonAdaptedTask {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     TaskDeadline.class.getSimpleName()));
         }
-        if (!TaskDeadline.isValidTaskDeadline(taskDeadline)) {
+        if (!TaskDeadline.isValidDate(taskDeadline)) {
             throw new IllegalValueException(TaskDeadline.MESSAGE_CONSTRAINTS);
         }
         final TaskDeadline modelTaskDeadline = new TaskDeadline(taskDeadline);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -93,8 +93,9 @@ public class CommandTestUtil {
     public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT + "MATH*"; // '*' not allowed in subjects
     public static final String INVALID_LEVEL_DESC = " " + PREFIX_LEVEL + "P7";
     public static final String INVALID_TASK_DESC = " " + PREFIX_TASK_DESCRIPTION + "   "; // blank task description
-    public static final String INVALID_DEADLINE_DESC = " " + PREFIX_TASK_DEADLINE + "2024-14-23"; // invalid month
-    public static final String INVALID_PAST_DATE = " " + PREFIX_TASK_DEADLINE + "2001-09-11";
+    public static final String INVALID_DEADLINE_DESC = " " + PREFIX_TASK_DEADLINE + "2024-14-123"; // invalid format
+    public static final String INVALID_PAST_DATE = " " + PREFIX_TASK_DEADLINE + "2001-09-11"; // a past date
+    public static final String INVALID_NONEXISTENT_DATE = " " + PREFIX_TASK_DEADLINE + "2001-42-01"; // invalid month
     public static final String INVALID_TASK_INDEX = " " + PREFIX_TASK_INDEX + "1!";
     public static final String INVALID_LESSON_TIME_DESC = " " + PREFIX_LESSON_TIME + "every thurs";
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -56,8 +56,8 @@ public class CommandTestUtil {
     public static final String VALID_NOTE_BOB = "Always sleeping";
     public static final String VALID_TASK_DESCRIPTION_AMY = "Mark homework";
     public static final String VALID_TASK_DESCRIPTION_PROJECT = "Do project";
-    public static final String VALID_TASK_DEADLINE = "2024-10-15";
-    public static final String VALID_TASK_DEADLINE_AMY = "2024-01-01";
+    public static final String VALID_TASK_DEADLINE = "2035-10-15";
+    public static final String VALID_TASK_DEADLINE_AMY = "2035-01-01";
     public static final String VALID_TASK_INDEX = "1";
     public static final String VALID_LESSON_TIME_SUN = "SUN-11:00-13:00";
     public static final String VALID_LESSON_TIME_TUE = "TUE-00:00-02:00";
@@ -94,6 +94,7 @@ public class CommandTestUtil {
     public static final String INVALID_LEVEL_DESC = " " + PREFIX_LEVEL + "P7";
     public static final String INVALID_TASK_DESC = " " + PREFIX_TASK_DESCRIPTION + "   "; // blank task description
     public static final String INVALID_DEADLINE_DESC = " " + PREFIX_TASK_DEADLINE + "2024-14-23"; // invalid month
+    public static final String INVALID_PAST_DATE = " " + PREFIX_TASK_DEADLINE + "2001-09-11";
     public static final String INVALID_TASK_INDEX = " " + PREFIX_TASK_INDEX + "1!";
     public static final String INVALID_LESSON_TIME_DESC = " " + PREFIX_LESSON_TIME + "every thurs";
 

--- a/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NONEXISTENT_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PAST_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -90,6 +91,10 @@ public class AddTaskCommandParserTest {
         // invalid deadline
         assertParseFailure(parser, NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + INVALID_DEADLINE_DESC,
                 TaskDeadline.MESSAGE_CONSTRAINTS);
+
+        // Non-existent date for deadline
+        assertParseFailure(parser, NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + INVALID_NONEXISTENT_DATE,
+                TaskDeadline.MESSAGE_CONSTRAINTS_NONEXISTENT_DATE);
 
         // invalid deadline, past date
         assertParseFailure(parser, NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + INVALID_PAST_DATE,

--- a/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PAST_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
@@ -89,6 +90,10 @@ public class AddTaskCommandParserTest {
         // invalid deadline
         assertParseFailure(parser, NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + INVALID_DEADLINE_DESC,
                 TaskDeadline.MESSAGE_CONSTRAINTS);
+
+        // invalid deadline, past date
+        assertParseFailure(parser, NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + INVALID_PAST_DATE,
+                TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE);
 
         // non-empty preamble
         assertParseFailure(parser,

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -11,6 +11,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.model.student.task.TaskDeadline.MESSAGE_CONSTRAINTS;
+import static seedu.address.model.student.task.TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
@@ -38,6 +40,7 @@ public class ParserUtilTest {
     private static final String INVALID_SUBJECT = "subj";
     private static final String INVALID_TASK_DESCRIPTION = " ";
     private static final String INVALID_TASK_DEADLINE = "tomorrow";
+    private static final String INVALID_PAST_DATE = "2001-09-11";
     private static final String INVALID_LESSON_TIME = "every thurs";
 
     private static final String VALID_NAME = "Rachel Walker";
@@ -46,7 +49,7 @@ public class ParserUtilTest {
     private static final String VALID_SUBJECT_1 = "MATH";
     private static final String VALID_SUBJECT_2 = "ENGLISH";
     private static final String VALID_TASK_DESCRIPTION = "Mark work";
-    private static final String VALID_TASK_DEADLINE = "2024-01-01";
+    private static final String VALID_TASK_DEADLINE = "2035-01-01";
     private static final String VALID_LESSON_TIME = "SUN-11:00-13:30";
 
     private static final String WHITESPACE = " \t\r\n";
@@ -261,7 +264,14 @@ public class ParserUtilTest {
 
     @Test
     public void parseTaskDeadline_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTaskDeadline(INVALID_TASK_DEADLINE));
+        assertThrows(ParseException.class,
+                MESSAGE_CONSTRAINTS, () -> ParserUtil.parseTaskDeadline(INVALID_TASK_DEADLINE));
+    }
+
+    @Test
+    public void parseTaskDeadline_pastDates_throwsParseException() {
+        assertThrows(ParseException.class,
+                MESSAGE_CONSTRAINTS_PAST_DATE, () -> ParserUtil.parseTaskDeadline(INVALID_PAST_DATE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 import static seedu.address.model.student.task.TaskDeadline.MESSAGE_CONSTRAINTS;
+import static seedu.address.model.student.task.TaskDeadline.MESSAGE_CONSTRAINTS_NONEXISTENT_DATE;
 import static seedu.address.model.student.task.TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -41,6 +42,7 @@ public class ParserUtilTest {
     private static final String INVALID_TASK_DESCRIPTION = " ";
     private static final String INVALID_TASK_DEADLINE = "tomorrow";
     private static final String INVALID_PAST_DATE = "2001-09-11";
+    private static final String INVALID_DATE = "2001-42-69";
     private static final String INVALID_LESSON_TIME = "every thurs";
 
     private static final String VALID_NAME = "Rachel Walker";
@@ -272,6 +274,12 @@ public class ParserUtilTest {
     public void parseTaskDeadline_pastDates_throwsParseException() {
         assertThrows(ParseException.class,
                 MESSAGE_CONSTRAINTS_PAST_DATE, () -> ParserUtil.parseTaskDeadline(INVALID_PAST_DATE));
+    }
+
+    @Test
+    public void parseTaskDeadline_invalidDate_throwsParseException() {
+        assertThrows(ParseException.class,
+                MESSAGE_CONSTRAINTS_NONEXISTENT_DATE, () -> ParserUtil.parseTaskDeadline(INVALID_DATE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NONEXISTENT_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PAST_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -74,9 +76,13 @@ public class UpdateTaskCommandParserTest {
         assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_DEADLINE_DESC,
                 TaskDeadline.MESSAGE_CONSTRAINTS);
 
+        // Non-existent date for deadline
+        assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_NONEXISTENT_DATE,
+                TaskDeadline.MESSAGE_CONSTRAINTS_NONEXISTENT_DATE);
+
         // invalid task deadline, past date
-        assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_DEADLINE_DESC,
-                TaskDeadline.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_PAST_DATE,
+                TaskDeadline.MESSAGE_CONSTRAINTS_PAST_DATE);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,

--- a/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
@@ -74,6 +74,10 @@ public class UpdateTaskCommandParserTest {
         assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_DEADLINE_DESC,
                 TaskDeadline.MESSAGE_CONSTRAINTS);
 
+        // invalid task deadline, past date
+        assertParseFailure(parser, NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_DEADLINE_DESC,
+                TaskDeadline.MESSAGE_CONSTRAINTS);
+
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
                 NAME_DESC_AMY + TASK_INDEX_DESC + INVALID_TASK_DESC + INVALID_DEADLINE_DESC,

--- a/src/test/java/seedu/address/model/student/task/TaskDeadlineTest.java
+++ b/src/test/java/seedu/address/model/student/task/TaskDeadlineTest.java
@@ -22,6 +22,28 @@ public class TaskDeadlineTest {
     }
 
     @Test
+    public void isValidFormat() {
+        // null deadline
+        assertThrows(NullPointerException.class, () -> TaskDeadline.isValidFormat(null));
+
+        // valid format for comparison
+        assertTrue(TaskDeadline.isValidFormat("2036-02-29")); // Should be true in a leap year
+        assertTrue(TaskDeadline.isValidFormat("2035-02-28"));
+        assertTrue(TaskDeadline.isValidFormat("2035-12-31"));
+        assertTrue(TaskDeadline.isValidFormat("2035-01-01"));
+        assertTrue(TaskDeadline.isValidFormat("2035-42-99"));
+        assertTrue(TaskDeadline.isValidFormat("2035-42-01"));
+        assertTrue(TaskDeadline.isValidFormat("2035-01-99"));
+
+        // invalid format
+        assertFalse(TaskDeadline.isValidFormat(""));
+        assertFalse(TaskDeadline.isValidFormat(" "));
+        assertFalse(TaskDeadline.isValidFormat("tomorrow"));
+        assertFalse(TaskDeadline.isValidFormat("2035"));
+        assertFalse(TaskDeadline.isValidFormat("2035-1-1"));
+    }
+
+    @Test
     public void isValidTaskDeadline() {
         // null deadline
         assertThrows(NullPointerException.class, () -> TaskDeadline.isValidDate(null));
@@ -56,7 +78,7 @@ public class TaskDeadlineTest {
     }
 
     @Test
-    public void isValidDeadline() {
+    public void isValidDate() {
         // null deadline
         assertThrows(NullPointerException.class, () -> TaskDeadline.isValidDate(null));
 

--- a/src/test/java/seedu/address/model/student/task/TaskDeadlineTest.java
+++ b/src/test/java/seedu/address/model/student/task/TaskDeadlineTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 public class TaskDeadlineTest {
@@ -19,30 +22,64 @@ public class TaskDeadlineTest {
     }
 
     @Test
-    public void isValidDeadline() {
+    public void isValidTaskDeadline() {
         // null deadline
-        assertThrows(NullPointerException.class, () -> TaskDeadline.isValidTaskDeadline(null));
+        assertThrows(NullPointerException.class, () -> TaskDeadline.isValidDate(null));
 
         // valid date for comparison
-        assertTrue(TaskDeadline.isValidTaskDeadline("2024-02-29")); // Should be true in a leap year
-        assertTrue(TaskDeadline.isValidTaskDeadline("2023-02-28"));
-        assertTrue(TaskDeadline.isValidTaskDeadline("2026-12-31"));
-        assertTrue(TaskDeadline.isValidTaskDeadline("2024-01-01"));
+        assertTrue(TaskDeadline.isValidTaskDeadline("2036-02-29")); // Should be true in a leap year
+        assertTrue(TaskDeadline.isValidTaskDeadline("2035-02-28"));
+        assertTrue(TaskDeadline.isValidTaskDeadline("2035-12-31"));
+        assertTrue(TaskDeadline.isValidTaskDeadline("2035-01-01"));
 
         // invalid deadline
         assertFalse(TaskDeadline.isValidTaskDeadline(""));
         assertFalse(TaskDeadline.isValidTaskDeadline(" "));
         assertFalse(TaskDeadline.isValidTaskDeadline("tomorrow"));
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024"));
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024-1-1"));
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035"));
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035-1-1"));
 
         // invalid date: February 31 does not exist
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024-02-31")); // Should be false
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035-02-31")); // Should be false
 
         // other invalid dates
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024-04-31")); // April has only 30 days
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024-06-31")); // June has only 30 days
-        assertFalse(TaskDeadline.isValidTaskDeadline("2024-09-31")); // September has only 30 days
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035-04-31")); // April has only 30 days
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035-06-31")); // June has only 30 days
+        assertFalse(TaskDeadline.isValidTaskDeadline("2035-09-31")); // September has only 30 days
+
+        // Dates are in the past, before today.
+        assertFalse(TaskDeadline.isValidTaskDeadline("1899-12-31"));
+        assertFalse(TaskDeadline.isValidTaskDeadline("1111-02-28"));
+        assertFalse(TaskDeadline.isValidTaskDeadline("2022-12-31"));
+        String yesterday = LocalDate.now().plusDays(-1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        assertFalse(TaskDeadline.isValidTaskDeadline(yesterday));
+    }
+
+    @Test
+    public void isValidDeadline() {
+        // null deadline
+        assertThrows(NullPointerException.class, () -> TaskDeadline.isValidDate(null));
+
+        // valid date for comparison
+        assertTrue(TaskDeadline.isValidDate("2024-02-29")); // Should be true in a leap year
+        assertTrue(TaskDeadline.isValidDate("2023-02-28"));
+        assertTrue(TaskDeadline.isValidDate("2026-12-31"));
+        assertTrue(TaskDeadline.isValidDate("2024-01-01"));
+
+        // invalid deadline
+        assertFalse(TaskDeadline.isValidDate(""));
+        assertFalse(TaskDeadline.isValidDate(" "));
+        assertFalse(TaskDeadline.isValidDate("tomorrow"));
+        assertFalse(TaskDeadline.isValidDate("2024"));
+        assertFalse(TaskDeadline.isValidDate("2024-1-1"));
+
+        // invalid date: February 31 does not exist
+        assertFalse(TaskDeadline.isValidDate("2024-02-31")); // Should be false
+
+        // other invalid dates
+        assertFalse(TaskDeadline.isValidDate("2024-04-31")); // April has only 30 days
+        assertFalse(TaskDeadline.isValidDate("2024-06-31")); // June has only 30 days
+        assertFalse(TaskDeadline.isValidDate("2024-09-31")); // September has only 30 days
     }
 
     @Test


### PR DESCRIPTION
-Add a check to only allow dates today and onwards to be added. Past dates can still be loaded into addressbook to prevent existing task from breaking the addressbook /  being lost due to it expiring.

Closes #254 

- Add more error messages to be more clear on the problem with the user command.
Specifically:
- Format error -> shows format error 
- non-existent dates ->  shows date dont exist
- past dates -> the date has past

Closes #216 