### PR TITLE
All commands that uses prefixes now handles extra prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,6 +13,8 @@ import seedu.address.model.student.Student;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_CONTAIN_EXTRA_PREFIX = "Invalid command format! It contains extra prefixes!"
+            + "\n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided exceeds the number"
             + " of students in the list";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,14 +1,20 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 import static seedu.address.logic.parser.ParserUtil.parseNote;
 
 import java.util.HashSet;
@@ -39,7 +45,14 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
-                        PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME);
+                        PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME,
+                        PREFIX_NOTE, PREFIX_TASK_INDEX, PREFIX_TASK_DEADLINE, PREFIX_TASK_DESCRIPTION);
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_NOTE, PREFIX_TASK_INDEX,
+                PREFIX_TASK_DEADLINE, PREFIX_TASK_DESCRIPTION);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, AddCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMERGENCY_CONTACT, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTaskCommandParser.java
@@ -1,10 +1,20 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -23,7 +33,18 @@ public class AddTaskCommandParser implements Parser<AddTaskCommand> {
      */
     public AddTaskCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE,
+                        PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                        PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_NOTE, PREFIX_TASK_INDEX,
+                        PREFIX_LEVEL, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_NOTE, PREFIX_TASK_INDEX,
+                PREFIX_LEVEL, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, AddTaskCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -1,9 +1,20 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteTaskCommand;
@@ -22,7 +33,19 @@ public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
      */
     public DeleteTaskCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TASK_INDEX);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TASK_INDEX,
+                        PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION,
+                        PREFIX_TASK_DEADLINE, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION,
+                PREFIX_TASK_DEADLINE, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, DeleteTaskCommand.MESSAGE_USAGE));
+        }
+
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TASK_INDEX)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,10 +1,20 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import java.util.Arrays;
 
@@ -29,7 +39,18 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_LEVEL, PREFIX_SUBJECT);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_LEVEL, PREFIX_SUBJECT,
+                        PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_TASK_DESCRIPTION,
+                        PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_TASK_DESCRIPTION,
+                PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, FindCommand.MESSAGE_USAGE));
+        }
 
         boolean isByName = argMultimap.getValue(PREFIX_NAME).isPresent();
         boolean isByLevel = argMultimap.getValue(PREFIX_LEVEL).isPresent();

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -1,9 +1,20 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 import static seedu.address.logic.parser.ParserUtil.parseNote;
 
 import seedu.address.logic.commands.NoteCommand;
@@ -20,7 +31,18 @@ public class NoteCommandParser implements Parser<NoteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public NoteCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NOTE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NOTE,
+                PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE,
+                PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE,
+                PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, NoteCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NOTE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -29,12 +29,21 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a positive integer.";
     public static final String MESSAGE_INVALID_TASK_INDEX = "Task index is not a positive integer.";
+
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
     public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if any of the prefixes contains {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean isAnyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -1,11 +1,21 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UpdateCommand.UpdateStudentDescriptor;
@@ -26,9 +36,19 @@ public class TagCommandParser implements Parser<TagCommand> {
     public TagCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultiMap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_SUBJECT, PREFIX_LEVEL);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_SUBJECT, PREFIX_LEVEL,
+                        PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS, PREFIX_NOTE,
+                        PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX,
+                        PREFIX_LESSON_TIME);
         argMultiMap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_LEVEL);
 
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultiMap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX,
+                PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, TagCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultiMap, PREFIX_NAME) || !argMultiMap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
@@ -10,6 +11,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,8 +42,15 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
-                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME);
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME,
+                        PREFIX_TASK_INDEX, PREFIX_TASK_DEADLINE, PREFIX_TASK_DESCRIPTION);
 
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_TASK_INDEX,
+                PREFIX_TASK_DEADLINE, PREFIX_TASK_DESCRIPTION);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, UpdateCommand.MESSAGE_USAGE));
+        }
         if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/UpdateTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateTaskCommandParser.java
@@ -1,12 +1,21 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 import static seedu.address.logic.parser.ParserUtil.parseName;
 import static seedu.address.logic.parser.ParserUtil.parseTaskIndex;
 
@@ -31,7 +40,16 @@ public class UpdateTaskCommandParser implements Parser<UpdateTaskCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TASK_INDEX, PREFIX_TASK_DESCRIPTION,
-                        PREFIX_TASK_DEADLINE);
+                        PREFIX_TASK_DEADLINE,
+                        PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                        PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, UpdateTaskCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TASK_INDEX)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,8 +1,20 @@
 package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,7 +31,18 @@ public class ViewCommandParser implements Parser<ViewCommand> {
      */
     public ViewCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+                PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION,
+                PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        boolean isExtraPrefix = isAnyPrefixPresent(argMultimap, PREFIX_PHONE, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ADDRESS, PREFIX_NOTE, PREFIX_SUBJECT, PREFIX_LEVEL, PREFIX_TASK_DESCRIPTION,
+                PREFIX_TASK_DEADLINE, PREFIX_TASK_INDEX, PREFIX_LESSON_TIME);
+
+        if (isExtraPrefix) {
+            throw new ParseException(String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, ViewCommand.MESSAGE_USAGE));
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
@@ -18,12 +19,16 @@ import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_NA;
 import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S4_NT;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_TUE;
@@ -213,6 +218,29 @@ public class AddCommandParserTest {
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_ADDRESS_BOB,
+                expectedMessage);
+    }
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, AddCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB + PHONE_DESC_BOB + EMERGENCY_CONTACT_DESC_BOB
+                + ADDRESS_DESC_BOB + LEVEL_DESC_S1_NA + SUBJECT_DESC_ENGLISH;
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_AMY + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_AMY + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_AMY + validExpectedStudentString,
                 expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTaskCommandParserTest.java
@@ -1,14 +1,23 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_DEADLINE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_DESCRIPTION_PROJECT;
@@ -73,6 +82,45 @@ public class AddTaskCommandParserTest {
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_TASK_DESCRIPTION_PROJECT + VALID_TASK_DEADLINE,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, AddTaskCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB + TASK_DESCRIPTION_DESC_BOB + TASK_DEADLINE_DESC_BOB;
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Subject Prefix
+        assertParseFailure(parser, SUBJECT_DESC_ENGLISH + validExpectedStudentString,
+                expectedMessage);
+
+        //have Level Prefix
+        assertParseFailure(parser, LEVEL_DESC_S1_EXPRESS + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_AMY + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
                 expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
@@ -1,9 +1,19 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TASK_INDEX;
@@ -80,6 +90,49 @@ public class DeleteTaskCommandParserTest {
     @Test
     public void parse_invalidIndexArgs_throwsParseException() {
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_TASK_INDEX, MESSAGE_INVALID_TASK_INDEX);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, DeleteTaskCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = " n/ Bob Choo  ti/ 1 ";
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Subject Prefix
+        assertParseFailure(parser, SUBJECT_DESC_ENGLISH + validExpectedStudentString,
+                expectedMessage);
+
+        //have Level Prefix
+        assertParseFailure(parser, LEVEL_DESC_S1_EXPRESS + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -96,6 +105,45 @@ public class FindCommandParserTest {
         assertParseFailure(parser, " s/MATHEMATIC", Subject.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " s/    ", Subject.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " s/", Subject.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, FindCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = " n/Alice Bob";
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
@@ -1,8 +1,19 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -52,5 +63,48 @@ public class NoteCommandParserTest {
 
         // no note
         assertParseFailure(parser, NAME_DESC_AMY, expectedMessage);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, NoteCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB + NOTE_DESC_BOB;
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Subject Prefix
+        assertParseFailure(parser, SUBJECT_DESC_ENGLISH + validExpectedStudentString,
+                expectedMessage);
+
+        //have Level Prefix
+        assertParseFailure(parser, LEVEL_DESC_S1_EXPRESS + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_TASK_INDEX;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.isAnyPrefixPresent;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
@@ -65,6 +66,22 @@ public class ParserUtilTest {
 
         // None are present
         assertFalse(arePrefixesPresent(argumentMultimap, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS));
+    }
+
+    @Test
+    public void isAnyPrefixPresentTest() {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_NAME, "name");
+        argumentMultimap.put(PREFIX_NOTE, "");
+
+        // All are present
+        assertTrue(isAnyPrefixPresent(argumentMultimap, PREFIX_NAME, PREFIX_NOTE));
+
+        // some are present
+        assertTrue(isAnyPrefixPresent(argumentMultimap, PREFIX_NOTE, PREFIX_TASK_INDEX));
+
+        // None are present
+        assertFalse(isAnyPrefixPresent(argumentMultimap, PREFIX_EMERGENCY_CONTACT, PREFIX_ADDRESS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -1,13 +1,22 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LEVEL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBJECT_ENGLISH;
@@ -103,6 +112,45 @@ public class TagCommandParserTest {
         assertParseFailure(parser, TagCommand.COMMAND_WORD + " asdasdadcad" + NAME_DESC_BOB,
                 MESSAGE_INVALID_FORMAT);
 
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, TagCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB + SUBJECT_DESC_MATH + LEVEL_DESC_S1_EXPRESS;
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
@@ -17,6 +18,9 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_MATH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_SUN;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LEVEL_S4_NT;
@@ -75,6 +79,26 @@ public class UpdateCommandParserTest {
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String validExpectedStudentString = PHONE_DESC_BOB + SUBJECT_DESC_MATH
+                + ADDRESS_DESC_AMY + NAME_DESC_AMY + SUBJECT_DESC_ENGLISH + LESSON_TIME_SUN_DESC;
+
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, UpdateCommand.MESSAGE_USAGE);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, validExpectedStudentString + TASK_INDEX_DESC,
+                expectedMessage);
+
+        //have Task deadline Prefix
+        assertParseFailure(parser, validExpectedStudentString + TASK_DEADLINE_DESC_AMY,
+                expectedMessage);
+
+        //have Task description Prefix
+        assertParseFailure(parser, validExpectedStudentString + TASK_DESCRIPTION_DESC_AMY,
+                expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateTaskCommandParserTest.java
@@ -1,12 +1,20 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DEADLINE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_AMY;
@@ -55,6 +63,42 @@ public class UpdateTaskCommandParserTest {
 
         // nothing specified
         assertParseFailure(parser, "   ", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, UpdateTaskCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB + TASK_INDEX_DESC + TASK_DESCRIPTION_DESC_BOB
+                + TASK_DEADLINE_DESC_BOB;
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Subject Prefix
+        assertParseFailure(parser, SUBJECT_DESC_ENGLISH + validExpectedStudentString,
+                expectedMessage);
+
+        //have Level Prefix
+        assertParseFailure(parser, LEVEL_DESC_S1_EXPRESS + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_AMY + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -1,9 +1,19 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_CONTAIN_EXTRA_PREFIX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMERGENCY_CONTACT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_SUN_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LEVEL_DESC_S1_EXPRESS;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_ENGLISH;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DEADLINE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TASK_INDEX_DESC;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalStudents.AMY;
@@ -22,14 +32,58 @@ public class ViewCommandParserTest {
     }
 
     @Test
+    public void parse_extraPrefix_failure() {
+        String expectedMessage = String.format(MESSAGE_CONTAIN_EXTRA_PREFIX, ViewCommand.MESSAGE_USAGE);
+
+        String validExpectedStudentString = NAME_DESC_BOB;
+
+        //have Phone Prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have E-Contact Prefix
+        assertParseFailure(parser, EMERGENCY_CONTACT_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Address Prefix
+        assertParseFailure(parser, ADDRESS_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Subject Prefix
+        assertParseFailure(parser, SUBJECT_DESC_ENGLISH + validExpectedStudentString,
+                expectedMessage);
+
+        //have Level Prefix
+        assertParseFailure(parser, LEVEL_DESC_S1_EXPRESS + validExpectedStudentString,
+                expectedMessage);
+
+        //have Note Prefix
+        assertParseFailure(parser, NOTE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Description Prefix
+        assertParseFailure(parser, TASK_DESCRIPTION_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Deadline Prefix
+        assertParseFailure(parser, TASK_DEADLINE_DESC_BOB + validExpectedStudentString,
+                expectedMessage);
+
+        //have Task Index Prefix
+        assertParseFailure(parser, TASK_INDEX_DESC + validExpectedStudentString,
+                expectedMessage);
+
+        //have LessonTime Prefix
+        assertParseFailure(parser, LESSON_TIME_SUN_DESC + validExpectedStudentString,
+                expectedMessage);
+    }
+
+    @Test
     public void parse_missingCompulsoryField_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE);
 
         // no parameters
         assertParseFailure(parser, "", expectedMessage);
-
-        // no name specified
-        assertParseFailure(parser, PHONE_DESC_AMY, expectedMessage);
 
         // non-empty preamble
         assertParseFailure(parser, " asdasdadcad" + NAME_DESC_AMY, expectedMessage);


### PR DESCRIPTION
Does not handle extra prefixes well and gives the wrong error message. Need to add checks and return a new error message for user.


Let's:
* add an additional layer of check to see if unwanted prefixes are in the command and give a new error to tell them that they should not have it in the command
* add more tests to cover the changes
Closes #230 